### PR TITLE
fix(panel): resolve sidebar panel not appearing after installation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
       - name: Validate Python syntax
         run: |
           find custom_components/finance_dashboard -name "*.py" -exec python -m py_compile {} +

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -25,6 +25,7 @@ class FinanceDashboardPanel extends HTMLElement {
     super();
     this.attachShadow({ mode: "open" });
     this._hass = null;
+    this._panel = null;
   }
 
   set hass(hass) {
@@ -33,6 +34,10 @@ class FinanceDashboardPanel extends HTMLElement {
       this._render();
     }
     this._refresh();
+  }
+
+  set panel(panel) {
+    this._panel = panel;
   }
 
   _render() {
@@ -303,4 +308,8 @@ class FinanceDashboardPanel extends HTMLElement {
 
 }
 
-customElements.define("finance-dashboard-panel", FinanceDashboardPanel);
+if (!customElements.get("finance-dashboard-panel")) {
+  customElements.define("finance-dashboard-panel", FinanceDashboardPanel);
+}
+
+export default FinanceDashboardPanel;

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -8,7 +8,8 @@
   "dependencies": [
     "persistent_notification",
     "http",
-    "frontend"
+    "frontend",
+    "panel_custom"
   ],
   "integration_type": "service",
   "documentation": "https://github.com/Jerry0022/homeassistant-finance",

--- a/custom_components/finance_dashboard/panel.py
+++ b/custom_components/finance_dashboard/panel.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components import panel_custom
+from homeassistant.components import frontend, panel_custom
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant
@@ -33,33 +33,46 @@ async def async_register_panel(hass: HomeAssistant) -> None:
     Creates a sidebar entry that loads the finance dashboard
     web component from the integration's static files.
     """
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                STATIC_BASE,
-                hass.config.path("custom_components", DOMAIN, "frontend"),
-                True,
-            )
-        ]
-    )
+    try:
+        # Register static file path for frontend assets
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    STATIC_BASE,
+                    hass.config.path(
+                        "custom_components", DOMAIN, "frontend"
+                    ),
+                    False,
+                )
+            ]
+        )
 
-    await panel_custom.async_register_panel(
-        hass,
-        webcomponent_name=PANEL_COMPONENT_NAME,
-        frontend_url_path=PANEL_URL_PATH,
-        module_url=PANEL_MODULE_PATH,
-        sidebar_title=PANEL_TITLE,
-        sidebar_icon=PANEL_ICON,
-        require_admin=False,
-        config={"domain": DOMAIN},
-    )
+        # Register the sidebar panel via panel_custom API
+        await panel_custom.async_register_panel(
+            hass,
+            webcomponent_name=PANEL_COMPONENT_NAME,
+            frontend_url_path=PANEL_URL_PATH,
+            module_url=PANEL_MODULE_PATH,
+            sidebar_title=PANEL_TITLE,
+            sidebar_icon=PANEL_ICON,
+            require_admin=False,
+            config={"domain": DOMAIN},
+        )
 
-    for url in LOVELACE_COMPONENTS:
-        add_extra_js_url(hass, url)
+        # Register Lovelace card JS for automations
+        for url in LOVELACE_COMPONENTS:
+            add_extra_js_url(hass, url)
 
-    _LOGGER.debug("Finance Dashboard panel registered at /%s", PANEL_URL_PATH)
+        _LOGGER.debug(
+            "Finance Dashboard panel registered at /%s", PANEL_URL_PATH
+        )
+    except Exception:
+        _LOGGER.exception("Failed to register Finance Dashboard panel")
 
 
 async def async_unregister_panel(hass: HomeAssistant) -> None:
     """Unregister custom sidebar panel."""
-    panel_custom.async_unregister_panel(hass, PANEL_URL_PATH)
+    try:
+        frontend.async_remove_panel(hass, PANEL_URL_PATH)
+    except Exception:
+        _LOGGER.debug("Panel was not registered, nothing to remove")

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -25,6 +25,7 @@ class FinanceDashboardPanel extends HTMLElement {
     super();
     this.attachShadow({ mode: "open" });
     this._hass = null;
+    this._panel = null;
   }
 
   set hass(hass) {
@@ -33,6 +34,10 @@ class FinanceDashboardPanel extends HTMLElement {
       this._render();
     }
     this._refresh();
+  }
+
+  set panel(panel) {
+    this._panel = panel;
   }
 
   _render() {
@@ -303,4 +308,8 @@ class FinanceDashboardPanel extends HTMLElement {
 
 }
 
-customElements.define("finance-dashboard-panel", FinanceDashboardPanel);
+if (!customElements.get("finance-dashboard-panel")) {
+  customElements.define("finance-dashboard-panel", FinanceDashboardPanel);
+}
+
+export default FinanceDashboardPanel;

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -8,7 +8,8 @@
   "dependencies": [
     "persistent_notification",
     "http",
-    "frontend"
+    "frontend",
+    "panel_custom"
   ],
   "integration_type": "service",
   "documentation": "https://github.com/Jerry0022/homeassistant-finance",

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components import panel_custom
+from homeassistant.components import frontend, panel_custom
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant
@@ -33,33 +33,46 @@ async def async_register_panel(hass: HomeAssistant) -> None:
     Creates a sidebar entry that loads the finance dashboard
     web component from the integration's static files.
     """
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                STATIC_BASE,
-                hass.config.path("custom_components", DOMAIN, "frontend"),
-                True,
-            )
-        ]
-    )
+    try:
+        # Register static file path for frontend assets
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    STATIC_BASE,
+                    hass.config.path(
+                        "custom_components", DOMAIN, "frontend"
+                    ),
+                    False,
+                )
+            ]
+        )
 
-    await panel_custom.async_register_panel(
-        hass,
-        webcomponent_name=PANEL_COMPONENT_NAME,
-        frontend_url_path=PANEL_URL_PATH,
-        module_url=PANEL_MODULE_PATH,
-        sidebar_title=PANEL_TITLE,
-        sidebar_icon=PANEL_ICON,
-        require_admin=False,
-        config={"domain": DOMAIN},
-    )
+        # Register the sidebar panel via panel_custom API
+        await panel_custom.async_register_panel(
+            hass,
+            webcomponent_name=PANEL_COMPONENT_NAME,
+            frontend_url_path=PANEL_URL_PATH,
+            module_url=PANEL_MODULE_PATH,
+            sidebar_title=PANEL_TITLE,
+            sidebar_icon=PANEL_ICON,
+            require_admin=False,
+            config={"domain": DOMAIN},
+        )
 
-    for url in LOVELACE_COMPONENTS:
-        add_extra_js_url(hass, url)
+        # Register Lovelace card JS for automations
+        for url in LOVELACE_COMPONENTS:
+            add_extra_js_url(hass, url)
 
-    _LOGGER.debug("Finance Dashboard panel registered at /%s", PANEL_URL_PATH)
+        _LOGGER.debug(
+            "Finance Dashboard panel registered at /%s", PANEL_URL_PATH
+        )
+    except Exception:
+        _LOGGER.exception("Failed to register Finance Dashboard panel")
 
 
 async def async_unregister_panel(hass: HomeAssistant) -> None:
     """Unregister custom sidebar panel."""
-    panel_custom.async_unregister_panel(hass, PANEL_URL_PATH)
+    try:
+        frontend.async_remove_panel(hass, PANEL_URL_PATH)
+    except Exception:
+        _LOGGER.debug("Panel was not registered, nothing to remove")


### PR DESCRIPTION
## Summary
- Add `panel_custom` to `manifest.json` dependencies — HA must load it before our integration calls `panel_custom.async_register_panel()`
- Replace non-existent `panel_custom.async_unregister_panel()` with `frontend.async_remove_panel()` (the correct HA core API)
- Add `set panel(panel)` setter to web component — HA passes panel config object, missing setter causes silent failure
- Add ES module `export default` — `module_url` loads as `<script type="module">`, requires export syntax
- Guard `customElements.define()` with `.get()` check to prevent `DOMException` on config entry reload
- Wrap panel registration in try/except to prevent panel failure from taking down the entire integration
- Disable static path cache headers for development reliability
- Sync all fixes to companion add-on payload

## Test plan
- [ ] Install integration via companion add-on
- [ ] Restart Home Assistant
- [ ] Verify "Finance Dashboard" appears in the sidebar
- [ ] Click sidebar entry — panel loads without JS errors
- [ ] Reload config entry — no duplicate panel errors in logs
- [ ] Unload config entry — panel removed cleanly from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)