### PR TITLE
feat(scripts): CHANGELOG sync from BUILDLOG + catch-up to v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,108 @@
 
 All notable changes to the Finance will be documented in this file.
 
+## [0.7.3] — 2026-03-26
+
+### Fixed
+- Setup wizard race condition — guard flag prevents wizard re-trigger during entry reload
+- Account defaults in step 3 — merge existing settings into pending accounts
+
+## [0.7.2] — 2026-03-26
+
+### Fixed
+- `setup/complete` merges new accounts with existing ones instead of replacing entry.data
+- Dashboard `_refresh()` uses independent `.catch()` per endpoint instead of `Promise.all`
+- Manage accounts dialog retries 3x with 2s delay before showing error
+
+## [0.7.1] — 2026-03-26
+
+### Fixed
+- Defer settings overlay render to prevent flash on load
+- Correct balance data display in account cards
+
+## [0.7.0] — 2026-03-26
+
+### Added
+- Cascading transfer chain detection
+
+## [0.6.15] — 2026-03-26
+
+### Added
+- Gesamtsaldo uses actual bank balances from `/balances` API instead of transaction sums
+- Settings gear icon in dashboard header for account management
+- Manage-accounts overlay with rename, type change, person assignment, connect new bank
+- New `update_accounts` endpoint and account details in `setup/status`
+
+## [0.6.14] — 2026-03-26
+
+### Added
+- Shimmer skeleton loaders replacing plain loading text
+- Async refresh indicator (pulsing dot + timestamp) — old data stays visible
+- Responsive breakpoints for tablet (≤900px) and mobile (≤480px)
+- Improved empty state with SVG icon and descriptive text
+
+## [0.6.12] — 2026-03-26
+
+### Added
+- Step 3 offers HA user multi-select chips (n:m) instead of free-text person field
+- Custom display name field per account
+- New `GET /api/finance_dashboard/setup/users` endpoint for HA user list
+- New fields propagated through manager, sensor attributes, and transaction tagging
+
+## [0.6.9] — 2026-03-26
+
+### Fixed
+- RepairsFlow calls `homeassistant.restart` service when user confirms
+- Repair notification title says "Restart Required" instead of "Update Available"
+- Updated EN and DE translations for restart repair flow
+
+## [0.6.5] — 2026-03-25
+
+### Fixed
+- Retry logic and error handling in EnableBanking client for bank list API calls
+- Graceful error handling when fetching supported banks fails
+- Frontend error state with actionable feedback for bank list loading failures
+- Improved error response handling for bank list endpoint
+
+## [0.6.4] — 2026-03-25
+
+### Fixed
+- Return dict from `async_get_api_credentials` instead of tuple (callers expected dict-style access; tuple caused TypeError)
+
+## [0.6.3] — 2026-03-25
+
+### Fixed
+- Backend returns typed errors (`error_type`) for differentiated frontend handling
+- Frontend shows specific German error messages per error type
+- Credential errors link to integration settings instead of retry
+- 5-minute polling timeout in Step 2, cancel button to return to Step 1
+
+## [0.6.2] — 2026-03-25
+
+### Fixed
+- Move restart marker poll outside `is_configured`, check on startup, remove persistent notification fallback
+
+## [0.6.1] — 2026-03-25
+
+### Fixed
+- 30s timeout added to Enable Banking API, error state with retry button
+- Rename "Finance Dashboard" to "Finance" everywhere
+
+## [0.6.0] — 2026-03-25
+
+### Changed
+- **Breaking**: Bank setup moved from config flow to dashboard panel setup wizard
+- Config flow reduced to credentials-only (1 step, config VERSION 3)
+- Config entry migration v2→v3 preserves existing setups
+
+### Added
+- 4-step setup wizard overlay in Finance sidebar panel
+- 4 new setup API endpoints (status, institutions, authorize, complete)
+
+### Fixed
+- Enable Banking API: `authorization_id` field, nested IBAN, UUID state
+- Panel registration: `StaticPathConfig` with cache, correct unregister
+
 ## [0.5.5] — 2026-03-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ homeassistant-finance/
 ├── www/community/finance-dashboard/       # Lovelace card (HACS install)
 ├── scripts/                               # Dev tooling
 │   ├── bump_versions.py         # Sync versions across manifest/addon/const
-│   └── sync_addon_payload.py    # Copy integration → add-on payload
+│   ├── sync_addon_payload.py    # Copy integration → add-on payload
+│   └── sync_changelog.py       # Sync BUILDLOG → CHANGELOG (both root + addon)
 └── .github/workflows/validate.yml         # CI: syntax + version + payload validation
 ```
 
@@ -74,6 +75,10 @@ Three files must always have aligned versions:
 3. `custom_components/finance_dashboard/const.py` → `VERSION` constant
 
 Use `python scripts/bump_versions.py --part [patch|minor|major]` to bump all three atomically. The script also auto-syncs the add-on payload.
+
+### CHANGELOG Sync (mandatory after every BUILDLOG entry)
+
+After writing a BUILDLOG entry, run `python scripts/sync_changelog.py` to propagate the entry to both `CHANGELOG.md` (keep-a-changelog format) and `finance_dashboard_companion/CHANGELOG.md` (simplified). The script parses conventional commit prefixes (`feat()`, `fix()`, `refactor()`) and groups changes by Added/Changed/Fixed. Use `--check` to verify sync status.
 
 ## Key Patterns (from Golden Sample)
 
@@ -134,6 +139,11 @@ python scripts/bump_versions.py --part patch    # Bump version
 # Payload sync
 python scripts/sync_addon_payload.py            # Sync files
 python scripts/sync_addon_payload.py --check    # Verify sync
+
+# CHANGELOG sync (BUILDLOG → CHANGELOG + addon CHANGELOG)
+python scripts/sync_changelog.py                # Sync current version
+python scripts/sync_changelog.py --check        # Verify CHANGELOG is up-to-date
+python scripts/sync_changelog.py --version X.Y.Z  # Sync specific version
 
 # Validation (same as CI)
 python -m py_compile custom_components/finance_dashboard/__init__.py

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog
 
+## 0.7.3
+- Fix setup wizard race condition — guard flag prevents wizard re-trigger during entry reload
+- Fix account defaults in step 3 — merge existing settings into pending accounts
+
+## 0.7.2
+- Fix setup/complete merges new accounts with existing ones instead of replacing entry.data
+- Fix dashboard refresh uses independent error handling per endpoint
+- Fix manage accounts dialog retries 3x with 2s delay before showing error
+
+## 0.7.1
+- Fix settings overlay flash on load
+- Fix balance data display in account cards
+
+## 0.7.0
+- Cascading transfer chain detection
+
+## 0.6.15
+- Gesamtsaldo uses actual bank balances from /balances API
+- Settings gear icon in dashboard header for account management
+- Manage-accounts overlay with rename, type change, person assignment
+- New update_accounts endpoint and account details in setup/status
+
+## 0.6.14
+- Shimmer skeleton loaders replacing plain loading text
+- Async refresh indicator (pulsing dot + timestamp)
+- Responsive breakpoints for tablet and mobile
+- Improved empty state with SVG icon and descriptive text
+
+## 0.6.12
+- HA user multi-select chips in step 3 instead of free-text person field
+- Custom display name field per account
+- New setup/users endpoint for HA user list
+
+## 0.6.9
+- Fix RepairsFlow calls homeassistant.restart service when user confirms
+- Fix repair notification title says "Restart Required"
+- Updated EN and DE translations for restart repair flow
+
+## 0.6.5
+- Fix retry logic and error handling for bank list API calls
+- Fix graceful error handling when fetching supported banks fails
+- Fix frontend error state with actionable feedback
+
+## 0.6.4
+- Fix credential return type breaking bank list loading (dict instead of tuple)
+
+## 0.6.3
+- Fix backend returns typed errors for differentiated frontend handling
+- Fix frontend shows specific German error messages per error type
+- Fix credential errors link to integration settings
+- Fix 5-minute polling timeout in Step 2
+
+## 0.6.2
+- Fix restart marker poll outside is_configured, check on startup
+
+## 0.6.1
+- Fix 30s timeout for Enable Banking API, error state with retry button
+- Rename "Finance Dashboard" to "Finance" everywhere
+
+## 0.6.0
+- Move bank setup from config flow to dashboard panel setup wizard
+- Config flow reduced to credentials-only (1 step, config VERSION 3)
+- 4-step setup wizard overlay in Finance sidebar panel
+- 4 new setup API endpoints
+- Config entry migration v2 to v3
+
+## 0.5.5
+- Fix granular Enable Banking API debug logging
+
+## 0.5.2
+- Fix config flow error handling for PEM key format errors vs API auth failures
+
+## 0.5.1
+- Fix PEM private key field renders as multiline textarea
+- Remove deprecated arch values from companion add-on config
+- Step-by-step Enable Banking setup instructions
+
+## 0.5.0
+- Migrate from GoCardless to Enable Banking API
+- New EnableBankingClient with JWT RS256 signing
+- Config flow v2 with migration handler
+
 ## 0.4.3
 - Remove unused nordigen-python dependency (fixes 500 error on config flow)
 

--- a/scripts/sync_changelog.py
+++ b/scripts/sync_changelog.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Sync CHANGELOG.md from BUILDLOG.md entries.
+
+Parses the latest BUILDLOG entry and prepends a formatted CHANGELOG section.
+Also updates the companion add-on CHANGELOG.
+
+Usage:
+    python scripts/sync_changelog.py                    # Sync latest version
+    python scripts/sync_changelog.py --check            # Check if CHANGELOG is up-to-date
+    python scripts/sync_changelog.py --version 0.7.3    # Sync specific version
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+BUILDLOG_PATH = ROOT / "BUILDLOG.md"
+CHANGELOG_PATH = ROOT / "CHANGELOG.md"
+ADDON_CHANGELOG_PATH = ROOT / "finance_dashboard_companion" / "CHANGELOG.md"
+CONST_PATH = ROOT / "custom_components" / "finance_dashboard" / "const.py"
+
+
+def get_current_version() -> str:
+    text = CONST_PATH.read_text(encoding="utf-8")
+    match = re.search(r'^VERSION\s*=\s*"(\d+\.\d+\.\d+)"', text, re.MULTILINE)
+    return match.group(1) if match else "0.0.0"
+
+
+def get_changelog_latest_version() -> str:
+    text = CHANGELOG_PATH.read_text(encoding="utf-8")
+    match = re.search(r'##\s*\[?(\d+\.\d+\.\d+)\]?', text)
+    return match.group(1) if match else "0.0.0"
+
+
+def parse_buildlog_entry(version: str) -> dict | None:
+    """Extract a single BUILDLOG entry by version."""
+    text = BUILDLOG_PATH.read_text(encoding="utf-8")
+
+    # Match entry header with version
+    pattern = rf'##\s*(?:\[?v?{re.escape(version)}\]?)\s*(?:—\s*(\d{{4}}-\d{{2}}-\d{{2}}))?'
+    match = re.search(pattern, text)
+    if not match:
+        return None
+
+    date = match.group(1) or "unknown"
+    start = match.end()
+
+    # Find next entry
+    next_entry = re.search(r'\n##\s', text[start:])
+    end = start + next_entry.start() if next_entry else len(text)
+
+    body = text[start:end].strip()
+
+    # Extract change lines (lines starting with -)
+    changes = []
+    for line in body.split("\n"):
+        line = line.strip()
+        if line.startswith("- ") and not line.startswith("- **Build"):
+            # Clean up prefixes like "fix(x):" or "feat(x):"
+            changes.append(line)
+
+    return {"version": version, "date": date, "changes": changes}
+
+
+def classify_changes(changes: list[str]) -> dict[str, list[str]]:
+    """Group changes by type (Added, Changed, Fixed, Improved)."""
+    groups: dict[str, list[str]] = {}
+
+    for line in changes:
+        text = line.lstrip("- ").strip()
+
+        # Detect type from conventional commit prefix
+        if re.match(r'feat\(', text, re.IGNORECASE):
+            category = "Added"
+            text = re.sub(r'^feat\([^)]*\):\s*', '', text)
+        elif re.match(r'fix\(', text, re.IGNORECASE):
+            category = "Fixed"
+            text = re.sub(r'^fix\([^)]*\):\s*', '', text)
+        elif re.match(r'refactor\(', text, re.IGNORECASE):
+            category = "Changed"
+            text = re.sub(r'^refactor\([^)]*\):\s*', '', text)
+        elif "fix" in text[:20].lower():
+            category = "Fixed"
+        elif any(kw in text[:20].lower() for kw in ["add", "new", "feat"]):
+            category = "Added"
+        else:
+            # Default: infer from content
+            category = "Changed"
+
+        text = text[0].upper() + text[1:] if text else text
+        groups.setdefault(category, []).append(f"- {text}")
+
+    return groups
+
+
+def format_changelog_entry(entry: dict) -> str:
+    """Format a BUILDLOG entry as a CHANGELOG section."""
+    groups = classify_changes(entry["changes"])
+
+    lines = [f'## [{entry["version"]}] — {entry["date"]}', ""]
+
+    # Preferred order
+    for category in ["Added", "Changed", "Fixed", "Improved"]:
+        if category in groups:
+            lines.append(f"### {category}")
+            lines.extend(groups[category])
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def prepend_to_changelog(new_entry: str) -> None:
+    """Insert new entry after the file header."""
+    text = CHANGELOG_PATH.read_text(encoding="utf-8")
+
+    # Find insertion point (after header lines)
+    header_end = 0
+    for match in re.finditer(r'^(?:#[^#].*|All notable.*|$)\n', text, re.MULTILINE):
+        header_end = match.end()
+
+    before = text[:header_end].rstrip() + "\n\n"
+    after = text[header_end:].lstrip("\n")
+
+    CHANGELOG_PATH.write_text(before + new_entry + "\n" + after, encoding="utf-8")
+
+
+def update_addon_changelog(entry: dict) -> None:
+    """Update the companion add-on CHANGELOG (simplified format)."""
+    text = ADDON_CHANGELOG_PATH.read_text(encoding="utf-8")
+
+    # Build simplified entry
+    simplified = [f"## {entry['version']}"]
+    for change in entry["changes"]:
+        # Strip conventional commit prefix for addon changelog
+        line = change.lstrip("- ").strip()
+        line = re.sub(r'^(?:feat|fix|refactor)\([^)]*\):\s*', '', line)
+        line = line[0].upper() + line[1:] if line else line
+        simplified.append(f"- {line}")
+
+    new_section = "\n".join(simplified) + "\n"
+
+    # Insert after header
+    header_match = re.search(r'^# Changelog\s*\n', text)
+    if header_match:
+        insert_pos = header_match.end()
+        text = text[:insert_pos] + "\n" + new_section + "\n" + text[insert_pos:]
+    else:
+        text = "# Changelog\n\n" + new_section + "\n" + text
+
+    ADDON_CHANGELOG_PATH.write_text(text, encoding="utf-8")
+
+
+def check_sync() -> bool:
+    current = get_current_version()
+    changelog_latest = get_changelog_latest_version()
+
+    print(f"Current version:   {current}")
+    print(f"CHANGELOG latest:  {changelog_latest}")
+
+    if current == changelog_latest:
+        print("\nCHANGELOG is up-to-date.")
+        return True
+    else:
+        print(f"\nCHANGELOG is behind! Missing: {current}")
+        return False
+
+
+def sync_version(version: str) -> bool:
+    """Sync a single version from BUILDLOG to CHANGELOG."""
+    # Check if already in CHANGELOG
+    text = CHANGELOG_PATH.read_text(encoding="utf-8")
+    if re.search(rf'##\s*\[?{re.escape(version)}\]?', text):
+        print(f"v{version} already in CHANGELOG, skipping.")
+        return False
+
+    entry = parse_buildlog_entry(version)
+    if not entry:
+        print(f"v{version} not found in BUILDLOG.")
+        return False
+
+    if not entry["changes"]:
+        print(f"v{version} has no change lines in BUILDLOG, skipping.")
+        return False
+
+    formatted = format_changelog_entry(entry)
+    prepend_to_changelog(formatted)
+    update_addon_changelog(entry)
+    print(f"Synced v{version} to CHANGELOG.md and addon CHANGELOG.md")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sync CHANGELOG from BUILDLOG")
+    parser.add_argument("--check", action="store_true", help="Check if CHANGELOG is up-to-date")
+    parser.add_argument("--version", help="Sync a specific version")
+    args = parser.parse_args()
+
+    if args.check:
+        sys.exit(0 if check_sync() else 1)
+
+    if args.version:
+        sync_version(args.version)
+    else:
+        version = get_current_version()
+        sync_version(version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New `sync_changelog.py` script that parses BUILDLOG.md and generates both root and companion add-on CHANGELOGs
- Backfilled CHANGELOG.md with all entries from v0.6.0 through v0.7.3
- Updated companion add-on CHANGELOG with matching entries
- Added CHANGELOG sync rule to CLAUDE.md project instructions

## Details
The sync script (`scripts/sync_changelog.py`) reads structured BUILDLOG entries and produces Keep-a-Changelog formatted output. It supports `--check` mode for CI validation and handles both the root integration CHANGELOG and the companion add-on CHANGELOG.

No version bump — this is a docs/tooling-only change.

## Test plan
- [x] `python scripts/sync_changelog.py --check` passes
- [x] `python -m py_compile custom_components/finance_dashboard/__init__.py` passes
- [x] `node --check custom_components/finance_dashboard/frontend/finance-dashboard-panel.js` passes
- [x] `python scripts/bump_versions.py --check` — versions aligned at 0.7.3