### PR TITLE
feat(frontend): status chip replaces refresh button

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,13 @@
 # Build Log
 
+## v0.7.4 — 2026-03-26
+- **Build hash:** `pending`
+- **Branch:** claude/upbeat-davinci
+- **Changes:** feat(frontend): status chip replaces refresh button
+- feat(frontend): new `<finance-status-chip>` Lovelace component with 4 visual states (idle/loading/success/error)
+- refactor(frontend): panel header uses status chip instead of refresh button + dot indicator
+- feat(panel): register status chip JS as Lovelace extra module
+
 ## v0.7.3 — 2026-03-26
 - **Build hash:** `b1843b1`
 - **Branch:** claude/inspiring-albattani

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,17 @@ All notable changes to the Finance will be documented in this file.
 
 ## [0.1.0] — 2026-03-24
 
+## [0.7.4] — 2026-03-26
+
+### Added
+- **Changes:** feat(frontend): status chip replaces refresh button
+- New `<finance-status-chip>` Lovelace component with 4 visual states (idle/loading/success/error)
+- Register status chip JS as Lovelace extra module
+
+### Changed
+- **Branch:** claude/upbeat-davinci
+- Panel header uses status chip instead of refresh button + dot indicator
+
 ### Added
 - Initial project scaffold
 - GoCardless (Nordigen) Open Banking API client

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.7.3"
+VERSION = "0.7.4"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -5,6 +5,16 @@
  * Privacy-first: only aggregated data shown by default.
  */
 
+// Load the status chip component (needed inside shadow DOM)
+{
+  const base = document.currentScript?.src?.replace(/[^/]*$/, "") || "/api/finance_dashboard/static/";
+  if (!customElements.get("finance-status-chip")) {
+    const s = document.createElement("script");
+    s.src = base + "finance-status-chip.js";
+    document.head.appendChild(s);
+  }
+}
+
 class FinanceDashboardPanel extends HTMLElement {
   constructor() {
     super();
@@ -139,12 +149,8 @@ class FinanceDashboardPanel extends HTMLElement {
 .empty-title { font-size:18px; font-weight:600; margin-bottom:8px; }
 .empty-desc { font-size:14px; color:var(--tx2); max-width:360px; margin:0 auto; line-height:1.5; }
 
-/* Refresh indicator */
-.refresh-indicator { display:flex; align-items:center; gap:6px; font-size:11px; color:var(--tx2); }
-.refresh-indicator .ts { opacity:.7; }
-@keyframes pulse-dot { 0%,100% { opacity:.4; } 50% { opacity:1; } }
-.refresh-dot { width:6px; height:6px; border-radius:50%; background:var(--ac); display:none; }
-.refresh-dot.active { display:inline-block; animation:pulse-dot 1s ease-in-out infinite; }
+/* Status chip slot in header */
+finance-status-chip { vertical-align: middle; }
 
 .loading { text-align:center; padding:60px; color:var(--tx2); }
 
@@ -346,12 +352,8 @@ class FinanceDashboardPanel extends HTMLElement {
   <div class="hdr">
     <h1>Finance</h1>
     <div style="display:flex;align-items:center;gap:10px">
-      <div class="refresh-indicator">
-        <span class="refresh-dot" id="refreshDot"></span>
-        <span class="ts" id="lastUpdate"></span>
-      </div>
+      <finance-status-chip id="statusChip"></finance-status-chip>
       <button class="btn" id="monthBtn"></button>
-      <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
       <button class="btn-icon" id="settingsBtn" title="Konten verwalten">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
@@ -364,8 +366,8 @@ class FinanceDashboardPanel extends HTMLElement {
   <div id="overlay-container"></div>
 </div>`;
 
-    this.shadowRoot.getElementById("refreshBtn")
-      .addEventListener("click", () => this._refresh());
+    this.shadowRoot.getElementById("statusChip")
+      .addEventListener("retry", () => this._refresh());
     this.shadowRoot.getElementById("settingsBtn")
       .addEventListener("click", () => this._showManageOverlay());
     // Show skeleton immediately
@@ -391,24 +393,28 @@ class FinanceDashboardPanel extends HTMLElement {
       <div class="skel skel-bar"></div>`;
   }
 
-  _setRefreshing(active) {
-    const dot = this.shadowRoot.getElementById("refreshDot");
-    const btn = this.shadowRoot.getElementById("refreshBtn");
-    if (dot) dot.classList.toggle("active", active);
-    if (btn) {
-      btn.disabled = active;
-      btn.textContent = active ? "Wird geladen..." : "Aktualisieren";
-    }
+  /** @returns {FinanceStatusChip|null} */
+  _chip() {
+    return this.shadowRoot.getElementById("statusChip");
   }
 
-  _updateTimestamp() {
-    const el = this.shadowRoot.getElementById("lastUpdate");
-    if (!el) return;
-    const now = new Date();
-    const hh = String(now.getHours()).padStart(2, "0");
-    const mm = String(now.getMinutes()).padStart(2, "0");
-    el.textContent = `Stand ${hh}:${mm}`;
-    this._lastUpdateTime = now;
+  _setRefreshing(active) {
+    const chip = this._chip();
+    if (!chip) return;
+    if (active) {
+      chip.setState("loading");
+    }
+    // idle/success/error are set explicitly by _refresh()
+  }
+
+  _setSuccess() {
+    const chip = this._chip();
+    if (chip) chip.setState("success");
+  }
+
+  _setError(msg) {
+    const chip = this._chip();
+    if (chip) chip.setState("error", msg);
   }
 
   async _refresh() {
@@ -432,14 +438,14 @@ class FinanceDashboardPanel extends HTMLElement {
 
       if (!status.configured && !this._justCompletedSetup) {
         c.innerHTML = this._renderEmptyDashboard();
-        this._setRefreshing(false);
+        this._setSuccess();
         this._showSetupWizard();
         return;
       }
     } catch (e) {
       // Status endpoint failed — show empty state
       if (!hasData) c.innerHTML = this._renderEmptyDashboard();
-      this._setRefreshing(false);
+      this._setError("API nicht erreichbar");
       return;
     }
 
@@ -456,8 +462,7 @@ class FinanceDashboardPanel extends HTMLElement {
     ]);
     this._chainData = chains?.chains || [];
     this._draw(c, bal, txn, sum);
-    this._updateTimestamp();
-    this._setRefreshing(false);
+    this._setSuccess();
   }
 
   _renderEmptyDashboard() {

--- a/custom_components/finance_dashboard/frontend/finance-status-chip.js
+++ b/custom_components/finance_dashboard/frontend/finance-status-chip.js
@@ -1,0 +1,314 @@
+/**
+ * Finance Status Chip — Lovelace Component
+ *
+ * Reusable status indicator for the Finance Dashboard.
+ * Shows clear visual states: idle, loading, success, error.
+ *
+ * Usage in Lovelace:
+ *   type: custom:finance-status-chip
+ *
+ * Usage in panels / other components:
+ *   <finance-status-chip></finance-status-chip>
+ *   element.hass = hass;
+ *   element.setState("loading");
+ *   element.setState("success");
+ *   element.setState("error", "API nicht erreichbar");
+ *   element.setState("idle");
+ */
+
+const STATES = {
+  idle: { icon: "dot", label: null, cls: "idle" },
+  loading: { icon: "spinner", label: "Aktualisiert\u2026", cls: "loading" },
+  success: { icon: "check", label: "Aktualisiert", cls: "success" },
+  error: { icon: "alert", label: "Fehler", cls: "error" },
+};
+
+class FinanceStatusChip extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._state = "idle";
+    this._lastUpdate = null;
+    this._errorMsg = null;
+    this._successTimer = null;
+    this._rendered = false;
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._rendered) this._render();
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+  }
+
+  connectedCallback() {
+    if (!this._rendered) this._render();
+  }
+
+  /**
+   * Set the chip state. Called by parent components.
+   * @param {"idle"|"loading"|"success"|"error"} state
+   * @param {string} [errorMsg] - Optional error detail for error state
+   */
+  setState(state, errorMsg) {
+    if (this._successTimer) {
+      clearTimeout(this._successTimer);
+      this._successTimer = null;
+    }
+
+    this._state = state;
+    this._errorMsg = state === "error" ? (errorMsg || "Fehler") : null;
+
+    if (state === "success") {
+      this._lastUpdate = new Date();
+      this._successTimer = setTimeout(() => {
+        this._state = "idle";
+        this._update();
+      }, 2400);
+    }
+
+    if (state === "idle" && !this._lastUpdate) {
+      this._lastUpdate = new Date();
+    }
+
+    this._update();
+  }
+
+  /** Update timestamp without changing state */
+  setTimestamp(date) {
+    this._lastUpdate = date || new Date();
+    this._update();
+  }
+
+  _render() {
+    this._rendered = true;
+    this.shadowRoot.innerHTML = `
+<style>
+:host {
+  display: inline-flex;
+  --chip-bg: var(--card-background-color, #12121a);
+  --chip-bd: rgba(255,255,255,0.06);
+  --chip-tx: var(--primary-text-color, #e0e0e0);
+  --chip-tx2: var(--secondary-text-color, #9898a8);
+  --chip-ac: var(--accent-color, #4ecca3);
+  --chip-dg: #e74c3c;
+  --chip-wn: #f39c12;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-bd);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  font-size: 12px;
+  color: var(--chip-tx2);
+  cursor: default;
+  user-select: none;
+  transition: border-color 0.2s, background 0.2s;
+  min-width: 120px;
+  height: 32px;
+  box-sizing: border-box;
+}
+
+/* Clickable in error state */
+.chip.error {
+  cursor: pointer;
+  border-color: rgba(231, 76, 60, 0.3);
+  background: rgba(231, 76, 60, 0.06);
+}
+.chip.error:hover {
+  border-color: rgba(231, 76, 60, 0.5);
+  background: rgba(231, 76, 60, 0.1);
+}
+
+.chip.loading {
+  border-color: rgba(78, 204, 163, 0.2);
+}
+
+.chip.success {
+  border-color: rgba(78, 204, 163, 0.4);
+}
+
+/* Icons */
+.icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Idle dot */
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--chip-ac);
+  opacity: 0.7;
+}
+
+/* Spinner — CSS-only ring */
+@keyframes chip-spin {
+  to { transform: rotate(360deg); }
+}
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(78, 204, 163, 0.2);
+  border-top-color: var(--chip-ac);
+  border-radius: 50%;
+  animation: chip-spin 0.8s linear infinite;
+}
+
+/* Checkmark */
+.check svg {
+  width: 14px;
+  height: 14px;
+  color: var(--chip-ac);
+}
+
+/* Error icon */
+.alert svg {
+  width: 14px;
+  height: 14px;
+  color: var(--chip-dg);
+}
+
+/* Text */
+.label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chip.idle .label { color: var(--chip-tx2); }
+.chip.loading .label { color: var(--chip-ac); }
+.chip.success .label { color: var(--chip-ac); }
+.chip.error .label { color: var(--chip-dg); }
+
+/* Tooltip on error */
+.chip[title] { position: relative; }
+</style>
+
+<div class="chip idle" id="chip">
+  <div class="icon" id="icon"></div>
+  <span class="label" id="label"></span>
+</div>`;
+
+    this.shadowRoot.getElementById("chip")
+      .addEventListener("click", () => this._onClick());
+    this._update();
+  }
+
+  _update() {
+    if (!this._rendered) return;
+    const chip = this.shadowRoot.getElementById("chip");
+    const icon = this.shadowRoot.getElementById("icon");
+    const label = this.shadowRoot.getElementById("label");
+    if (!chip) return;
+
+    const s = STATES[this._state] || STATES.idle;
+
+    // Update class
+    chip.className = `chip ${s.cls}`;
+
+    // Update icon
+    icon.innerHTML = this._renderIcon(s.icon);
+
+    // Update label
+    const text = this._getLabelText(s);
+    label.textContent = text;
+
+    // Tooltip for error
+    if (this._state === "error" && this._errorMsg) {
+      chip.title = `${this._errorMsg} — Klicken zum Wiederholen`;
+    } else {
+      chip.removeAttribute("title");
+    }
+  }
+
+  _renderIcon(type) {
+    switch (type) {
+      case "dot":
+        return '<div class="dot"></div>';
+      case "spinner":
+        return '<div class="spinner"></div>';
+      case "check":
+        return '<div class="check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></div>';
+      case "alert":
+        return '<div class="alert"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></div>';
+      default:
+        return "";
+    }
+  }
+
+  _getLabelText(s) {
+    if (this._state === "error") {
+      return this._errorMsg || "Fehler";
+    }
+    if (s.label) return s.label;
+    // idle — show timestamp
+    if (this._lastUpdate) {
+      const hh = String(this._lastUpdate.getHours()).padStart(2, "0");
+      const mm = String(this._lastUpdate.getMinutes()).padStart(2, "0");
+      return `Stand ${hh}:${mm}`;
+    }
+    return "Bereit";
+  }
+
+  _onClick() {
+    if (this._state === "error") {
+      this.dispatchEvent(new CustomEvent("retry", { bubbles: true, composed: true }));
+    }
+  }
+
+  // --- Lovelace card interface ---
+  static getConfigElement() {
+    return document.createElement("finance-status-chip-editor");
+  }
+
+  static getStubConfig() {
+    return {};
+  }
+
+  getCardSize() {
+    return 1;
+  }
+}
+
+// Minimal editor for Lovelace card picker
+class FinanceStatusChipEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = Object.assign({}, config);
+    if (!this.innerHTML) {
+      this.innerHTML = `<div style="padding:16px;color:var(--secondary-text-color);font-size:13px;">
+        Status Chip zeigt automatisch den Aktualisierungsstatus des Finance Dashboard.
+      </div>`;
+    }
+  }
+
+  _dispatch() {
+    this.dispatchEvent(new CustomEvent("config-changed", {
+      detail: { config: this._config }, bubbles: true, composed: true,
+    }));
+  }
+}
+
+customElements.define("finance-status-chip", FinanceStatusChip);
+customElements.define("finance-status-chip-editor", FinanceStatusChipEditor);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "finance-status-chip",
+  name: "Finance Status Chip",
+  description: "Zeigt den Aktualisierungsstatus des Finance Dashboard",
+  preview: true,
+});

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.7.3"
+  "version": "0.7.4"
 }

--- a/custom_components/finance_dashboard/panel.py
+++ b/custom_components/finance_dashboard/panel.py
@@ -24,6 +24,7 @@ STATIC_BASE = f"/api/{DOMAIN}/static"
 LOVELACE_COMPONENTS = [
     f"{STATIC_BASE}/fd-budget-config.js",
     f"{STATIC_BASE}/fd-categorize.js",
+    f"{STATIC_BASE}/finance-status-chip.js",
 ]
 
 

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+
+## 0.7.4
+- **Branch:** claude/upbeat-davinci
+- **Changes:** feat(frontend): status chip replaces refresh button
+- New `<finance-status-chip>` Lovelace component with 4 visual states (idle/loading/success/error)
+- Panel header uses status chip instead of refresh button + dot indicator
+- Register status chip JS as Lovelace extra module
+
 ## 0.7.3
 - Fix setup wizard race condition — guard flag prevents wizard re-trigger during entry reload
 - Fix account defaults in step 3 — merge existing settings into pending accounts

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance
-version: "0.7.3"
+version: "0.7.4"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.7.3"
+VERSION = "0.7.4"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -5,6 +5,16 @@
  * Privacy-first: only aggregated data shown by default.
  */
 
+// Load the status chip component (needed inside shadow DOM)
+{
+  const base = document.currentScript?.src?.replace(/[^/]*$/, "") || "/api/finance_dashboard/static/";
+  if (!customElements.get("finance-status-chip")) {
+    const s = document.createElement("script");
+    s.src = base + "finance-status-chip.js";
+    document.head.appendChild(s);
+  }
+}
+
 class FinanceDashboardPanel extends HTMLElement {
   constructor() {
     super();
@@ -139,12 +149,8 @@ class FinanceDashboardPanel extends HTMLElement {
 .empty-title { font-size:18px; font-weight:600; margin-bottom:8px; }
 .empty-desc { font-size:14px; color:var(--tx2); max-width:360px; margin:0 auto; line-height:1.5; }
 
-/* Refresh indicator */
-.refresh-indicator { display:flex; align-items:center; gap:6px; font-size:11px; color:var(--tx2); }
-.refresh-indicator .ts { opacity:.7; }
-@keyframes pulse-dot { 0%,100% { opacity:.4; } 50% { opacity:1; } }
-.refresh-dot { width:6px; height:6px; border-radius:50%; background:var(--ac); display:none; }
-.refresh-dot.active { display:inline-block; animation:pulse-dot 1s ease-in-out infinite; }
+/* Status chip slot in header */
+finance-status-chip { vertical-align: middle; }
 
 .loading { text-align:center; padding:60px; color:var(--tx2); }
 
@@ -346,12 +352,8 @@ class FinanceDashboardPanel extends HTMLElement {
   <div class="hdr">
     <h1>Finance</h1>
     <div style="display:flex;align-items:center;gap:10px">
-      <div class="refresh-indicator">
-        <span class="refresh-dot" id="refreshDot"></span>
-        <span class="ts" id="lastUpdate"></span>
-      </div>
+      <finance-status-chip id="statusChip"></finance-status-chip>
       <button class="btn" id="monthBtn"></button>
-      <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
       <button class="btn-icon" id="settingsBtn" title="Konten verwalten">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
@@ -364,8 +366,8 @@ class FinanceDashboardPanel extends HTMLElement {
   <div id="overlay-container"></div>
 </div>`;
 
-    this.shadowRoot.getElementById("refreshBtn")
-      .addEventListener("click", () => this._refresh());
+    this.shadowRoot.getElementById("statusChip")
+      .addEventListener("retry", () => this._refresh());
     this.shadowRoot.getElementById("settingsBtn")
       .addEventListener("click", () => this._showManageOverlay());
     // Show skeleton immediately
@@ -391,24 +393,28 @@ class FinanceDashboardPanel extends HTMLElement {
       <div class="skel skel-bar"></div>`;
   }
 
-  _setRefreshing(active) {
-    const dot = this.shadowRoot.getElementById("refreshDot");
-    const btn = this.shadowRoot.getElementById("refreshBtn");
-    if (dot) dot.classList.toggle("active", active);
-    if (btn) {
-      btn.disabled = active;
-      btn.textContent = active ? "Wird geladen..." : "Aktualisieren";
-    }
+  /** @returns {FinanceStatusChip|null} */
+  _chip() {
+    return this.shadowRoot.getElementById("statusChip");
   }
 
-  _updateTimestamp() {
-    const el = this.shadowRoot.getElementById("lastUpdate");
-    if (!el) return;
-    const now = new Date();
-    const hh = String(now.getHours()).padStart(2, "0");
-    const mm = String(now.getMinutes()).padStart(2, "0");
-    el.textContent = `Stand ${hh}:${mm}`;
-    this._lastUpdateTime = now;
+  _setRefreshing(active) {
+    const chip = this._chip();
+    if (!chip) return;
+    if (active) {
+      chip.setState("loading");
+    }
+    // idle/success/error are set explicitly by _refresh()
+  }
+
+  _setSuccess() {
+    const chip = this._chip();
+    if (chip) chip.setState("success");
+  }
+
+  _setError(msg) {
+    const chip = this._chip();
+    if (chip) chip.setState("error", msg);
   }
 
   async _refresh() {
@@ -432,14 +438,14 @@ class FinanceDashboardPanel extends HTMLElement {
 
       if (!status.configured && !this._justCompletedSetup) {
         c.innerHTML = this._renderEmptyDashboard();
-        this._setRefreshing(false);
+        this._setSuccess();
         this._showSetupWizard();
         return;
       }
     } catch (e) {
       // Status endpoint failed — show empty state
       if (!hasData) c.innerHTML = this._renderEmptyDashboard();
-      this._setRefreshing(false);
+      this._setError("API nicht erreichbar");
       return;
     }
 
@@ -456,8 +462,7 @@ class FinanceDashboardPanel extends HTMLElement {
     ]);
     this._chainData = chains?.chains || [];
     this._draw(c, bal, txn, sum);
-    this._updateTimestamp();
-    this._setRefreshing(false);
+    this._setSuccess();
   }
 
   _renderEmptyDashboard() {

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-status-chip.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-status-chip.js
@@ -1,0 +1,314 @@
+/**
+ * Finance Status Chip — Lovelace Component
+ *
+ * Reusable status indicator for the Finance Dashboard.
+ * Shows clear visual states: idle, loading, success, error.
+ *
+ * Usage in Lovelace:
+ *   type: custom:finance-status-chip
+ *
+ * Usage in panels / other components:
+ *   <finance-status-chip></finance-status-chip>
+ *   element.hass = hass;
+ *   element.setState("loading");
+ *   element.setState("success");
+ *   element.setState("error", "API nicht erreichbar");
+ *   element.setState("idle");
+ */
+
+const STATES = {
+  idle: { icon: "dot", label: null, cls: "idle" },
+  loading: { icon: "spinner", label: "Aktualisiert\u2026", cls: "loading" },
+  success: { icon: "check", label: "Aktualisiert", cls: "success" },
+  error: { icon: "alert", label: "Fehler", cls: "error" },
+};
+
+class FinanceStatusChip extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._state = "idle";
+    this._lastUpdate = null;
+    this._errorMsg = null;
+    this._successTimer = null;
+    this._rendered = false;
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._rendered) this._render();
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+  }
+
+  connectedCallback() {
+    if (!this._rendered) this._render();
+  }
+
+  /**
+   * Set the chip state. Called by parent components.
+   * @param {"idle"|"loading"|"success"|"error"} state
+   * @param {string} [errorMsg] - Optional error detail for error state
+   */
+  setState(state, errorMsg) {
+    if (this._successTimer) {
+      clearTimeout(this._successTimer);
+      this._successTimer = null;
+    }
+
+    this._state = state;
+    this._errorMsg = state === "error" ? (errorMsg || "Fehler") : null;
+
+    if (state === "success") {
+      this._lastUpdate = new Date();
+      this._successTimer = setTimeout(() => {
+        this._state = "idle";
+        this._update();
+      }, 2400);
+    }
+
+    if (state === "idle" && !this._lastUpdate) {
+      this._lastUpdate = new Date();
+    }
+
+    this._update();
+  }
+
+  /** Update timestamp without changing state */
+  setTimestamp(date) {
+    this._lastUpdate = date || new Date();
+    this._update();
+  }
+
+  _render() {
+    this._rendered = true;
+    this.shadowRoot.innerHTML = `
+<style>
+:host {
+  display: inline-flex;
+  --chip-bg: var(--card-background-color, #12121a);
+  --chip-bd: rgba(255,255,255,0.06);
+  --chip-tx: var(--primary-text-color, #e0e0e0);
+  --chip-tx2: var(--secondary-text-color, #9898a8);
+  --chip-ac: var(--accent-color, #4ecca3);
+  --chip-dg: #e74c3c;
+  --chip-wn: #f39c12;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-bd);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  font-size: 12px;
+  color: var(--chip-tx2);
+  cursor: default;
+  user-select: none;
+  transition: border-color 0.2s, background 0.2s;
+  min-width: 120px;
+  height: 32px;
+  box-sizing: border-box;
+}
+
+/* Clickable in error state */
+.chip.error {
+  cursor: pointer;
+  border-color: rgba(231, 76, 60, 0.3);
+  background: rgba(231, 76, 60, 0.06);
+}
+.chip.error:hover {
+  border-color: rgba(231, 76, 60, 0.5);
+  background: rgba(231, 76, 60, 0.1);
+}
+
+.chip.loading {
+  border-color: rgba(78, 204, 163, 0.2);
+}
+
+.chip.success {
+  border-color: rgba(78, 204, 163, 0.4);
+}
+
+/* Icons */
+.icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Idle dot */
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--chip-ac);
+  opacity: 0.7;
+}
+
+/* Spinner — CSS-only ring */
+@keyframes chip-spin {
+  to { transform: rotate(360deg); }
+}
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(78, 204, 163, 0.2);
+  border-top-color: var(--chip-ac);
+  border-radius: 50%;
+  animation: chip-spin 0.8s linear infinite;
+}
+
+/* Checkmark */
+.check svg {
+  width: 14px;
+  height: 14px;
+  color: var(--chip-ac);
+}
+
+/* Error icon */
+.alert svg {
+  width: 14px;
+  height: 14px;
+  color: var(--chip-dg);
+}
+
+/* Text */
+.label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chip.idle .label { color: var(--chip-tx2); }
+.chip.loading .label { color: var(--chip-ac); }
+.chip.success .label { color: var(--chip-ac); }
+.chip.error .label { color: var(--chip-dg); }
+
+/* Tooltip on error */
+.chip[title] { position: relative; }
+</style>
+
+<div class="chip idle" id="chip">
+  <div class="icon" id="icon"></div>
+  <span class="label" id="label"></span>
+</div>`;
+
+    this.shadowRoot.getElementById("chip")
+      .addEventListener("click", () => this._onClick());
+    this._update();
+  }
+
+  _update() {
+    if (!this._rendered) return;
+    const chip = this.shadowRoot.getElementById("chip");
+    const icon = this.shadowRoot.getElementById("icon");
+    const label = this.shadowRoot.getElementById("label");
+    if (!chip) return;
+
+    const s = STATES[this._state] || STATES.idle;
+
+    // Update class
+    chip.className = `chip ${s.cls}`;
+
+    // Update icon
+    icon.innerHTML = this._renderIcon(s.icon);
+
+    // Update label
+    const text = this._getLabelText(s);
+    label.textContent = text;
+
+    // Tooltip for error
+    if (this._state === "error" && this._errorMsg) {
+      chip.title = `${this._errorMsg} — Klicken zum Wiederholen`;
+    } else {
+      chip.removeAttribute("title");
+    }
+  }
+
+  _renderIcon(type) {
+    switch (type) {
+      case "dot":
+        return '<div class="dot"></div>';
+      case "spinner":
+        return '<div class="spinner"></div>';
+      case "check":
+        return '<div class="check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></div>';
+      case "alert":
+        return '<div class="alert"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></div>';
+      default:
+        return "";
+    }
+  }
+
+  _getLabelText(s) {
+    if (this._state === "error") {
+      return this._errorMsg || "Fehler";
+    }
+    if (s.label) return s.label;
+    // idle — show timestamp
+    if (this._lastUpdate) {
+      const hh = String(this._lastUpdate.getHours()).padStart(2, "0");
+      const mm = String(this._lastUpdate.getMinutes()).padStart(2, "0");
+      return `Stand ${hh}:${mm}`;
+    }
+    return "Bereit";
+  }
+
+  _onClick() {
+    if (this._state === "error") {
+      this.dispatchEvent(new CustomEvent("retry", { bubbles: true, composed: true }));
+    }
+  }
+
+  // --- Lovelace card interface ---
+  static getConfigElement() {
+    return document.createElement("finance-status-chip-editor");
+  }
+
+  static getStubConfig() {
+    return {};
+  }
+
+  getCardSize() {
+    return 1;
+  }
+}
+
+// Minimal editor for Lovelace card picker
+class FinanceStatusChipEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = Object.assign({}, config);
+    if (!this.innerHTML) {
+      this.innerHTML = `<div style="padding:16px;color:var(--secondary-text-color);font-size:13px;">
+        Status Chip zeigt automatisch den Aktualisierungsstatus des Finance Dashboard.
+      </div>`;
+    }
+  }
+
+  _dispatch() {
+    this.dispatchEvent(new CustomEvent("config-changed", {
+      detail: { config: this._config }, bubbles: true, composed: true,
+    }));
+  }
+}
+
+customElements.define("finance-status-chip", FinanceStatusChip);
+customElements.define("finance-status-chip-editor", FinanceStatusChipEditor);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "finance-status-chip",
+  name: "Finance Status Chip",
+  description: "Zeigt den Aktualisierungsstatus des Finance Dashboard",
+  preview: true,
+});

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.7.3"
+  "version": "0.7.4"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
@@ -24,6 +24,7 @@ STATIC_BASE = f"/api/{DOMAIN}/static"
 LOVELACE_COMPONENTS = [
     f"{STATIC_BASE}/fd-budget-config.js",
     f"{STATIC_BASE}/fd-categorize.js",
+    f"{STATIC_BASE}/finance-status-chip.js",
 ]
 
 


### PR DESCRIPTION
## Summary
- New `<finance-status-chip>` Lovelace component with 4 visual states (idle/loading/success/error)
- Replaces old refresh button + dot indicator in panel header
- Fixed-width pill eliminates layout jitter during state changes
- Error state is clickable for retry, success auto-fades to idle
- Registered as Lovelace extra JS — embeddable in any dashboard via `custom:finance-status-chip`

## Test plan
- [ ] Panel loads with status chip showing "Bereit" or timestamp
- [ ] Refresh cycle: idle → loading (spinner) → success (checkmark) → idle (timestamp)
- [ ] API error shows red error chip, clicking retries
- [ ] No layout shift/jitter during state transitions
- [ ] Status chip usable as standalone Lovelace card

🤖 Generated with [Claude Code](https://claude.com/claude-code)