### PR TITLE
fix(core): handle HTTP 429 rate limit + fix en.json translation placeholders

### DIFF
--- a/custom_components/finance_dashboard/coordinator.py
+++ b/custom_components/finance_dashboard/coordinator.py
@@ -66,9 +66,11 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
             balances = await self._manager.async_get_balance()
             summary = await self._manager.async_get_monthly_summary()
 
+            rate_limited = self._manager.rate_limited_until
             return {
                 "balances": balances,
                 "summary": summary,
+                "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
             }
         except Exception as exc:
             raise UpdateFailed(f"Finance data update failed: {exc}") from exc

--- a/custom_components/finance_dashboard/enablebanking_client.py
+++ b/custom_components/finance_dashboard/enablebanking_client.py
@@ -23,6 +23,12 @@ from typing import Any
 import uuid
 
 import aiohttp
+
+from .const import ENABLEBANKING_RATE_LIMIT_DAILY
+
+
+class RateLimitExceeded(Exception):
+    """Raised when the banking API returns HTTP 429 (daily quota exhausted)."""
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -435,6 +441,12 @@ class EnableBankingClient:
                         resp.status,
                         body[:500],
                     )
+                    # Daily consent quota exhausted — signal callers to
+                    # stop retrying and serve cached data until tomorrow.
+                    if resp.status == 429:
+                        raise RateLimitExceeded(
+                            f"Daily API quota exhausted (HTTP 429): {body[:200]}"
+                        )
                     # Include the API error body in the exception
                     # so callers can surface it to the user
                     raise aiohttp.ClientResponseError(

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -101,6 +101,7 @@ class FdDataProvider extends HTMLElement {
         loading: false,
         error: null,
         lastRefresh: null,
+        rateLimitedUntil: null,
       };
 
       // 1. Read per-account balance sensors
@@ -145,6 +146,7 @@ class FdDataProvider extends HTMLElement {
         data.summary.month = sa.month || data.summary.month;
         data.summary.year = sa.year || data.summary.year;
         data.lastRefresh = sa.last_refresh || null;
+        data.rateLimitedUntil = sa.rate_limited_until || null;
 
         // Household and recurring from entity attrs (added in v0.7.9+)
         if (sa.household) data.household = sa.household;

--- a/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/custom_components/finance_dashboard/frontend/fd-header.js
@@ -14,6 +14,7 @@ class FdHeader extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this._lastRefresh = null;
     this._refreshing = false;
+    this._rateLimitedUntil = null;
   }
 
   set lastRefresh(v) {
@@ -23,10 +24,29 @@ class FdHeader extends HTMLElement {
 
   set refreshing(v) {
     this._refreshing = v;
+    this._updateRefreshBtn();
+  }
+
+  set rateLimitedUntil(v) {
+    this._rateLimitedUntil = v;
+    this._updateRefreshBtn();
+  }
+
+  _updateRefreshBtn() {
     const btn = this.shadowRoot.getElementById("refreshBtn");
-    if (btn) {
-      btn.disabled = v;
-      btn.textContent = v ? "Laden\u2026" : "Aktualisieren";
+    if (!btn) return;
+    if (this._rateLimitedUntil && new Date(this._rateLimitedUntil) > new Date()) {
+      btn.disabled = true;
+      btn.textContent = "Morgen verf\u00fcgbar";
+      btn.title = "Tageslimit der Bank-API erreicht. N\u00e4chste Aktualisierung ab morgen.";
+    } else if (this._refreshing) {
+      btn.disabled = true;
+      btn.textContent = "Laden\u2026";
+      btn.title = "";
+    } else {
+      btn.disabled = false;
+      btn.textContent = "Aktualisieren";
+      btn.title = "";
     }
   }
 

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -80,6 +80,12 @@ class FinanceDashboardPanel extends HTMLElement {
     this.shadowRoot.addEventListener("fd-refresh-requested", () => {
       const dp = this.shadowRoot.querySelector("fd-data-provider");
       const header = this.shadowRoot.querySelector("fd-header");
+      // Don't call the API if rate-limited — button should already be disabled,
+      // but guard here as well.
+      if (header && header._rateLimitedUntil &&
+          new Date(header._rateLimitedUntil) > new Date()) {
+        return;
+      }
       if (header) header.refreshing = true;
       if (dp) {
         dp.refresh().finally(() => {
@@ -103,9 +109,12 @@ class FinanceDashboardPanel extends HTMLElement {
     content.className = "";
     content.innerHTML = "";
 
-    // Update header timestamp
+    // Update header timestamp and rate limit state
     const header = this.shadowRoot.querySelector("fd-header");
-    if (header) header.lastRefresh = data.lastRefresh;
+    if (header) {
+      header.lastRefresh = data.lastRefresh;
+      header.rateLimitedUntil = data.rateLimitedUntil;
+    }
 
     // Stats row
     const statsRow = document.createElement("fd-stats-row");

--- a/custom_components/finance_dashboard/manager.py
+++ b/custom_components/finance_dashboard/manager.py
@@ -21,6 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN, STORAGE_KEY_TRANSFER_OVERRIDES, STORAGE_VERSION
+from .enablebanking_client import RateLimitExceeded
 from .household import HouseholdMember, HouseholdModel
 from .recurring import detect_recurring
 from .transfer_detector import (
@@ -55,12 +56,32 @@ class FinanceDashboardManager:
         self._transactions: list[dict[str, Any]] = []
         self._balances: dict[str, Any] = {}
         self._last_refresh: datetime | None = None
+        self._rate_limited_until: datetime | None = None
         self._transfer_override_store = Store(
             hass, 1, STORAGE_KEY_TRANSFER_OVERRIDES
         )
         self._transfer_overrides: dict[str, bool] = {}
         self._recurring_patterns: list[dict[str, Any]] = []
         self._previous_balances: dict[str, float] = {}
+
+    @property
+    def rate_limited_until(self) -> datetime | None:
+        """Return the datetime until which the API is rate-limited, or None."""
+        if self._rate_limited_until and datetime.now() < self._rate_limited_until:
+            return self._rate_limited_until
+        return None
+
+    def _set_rate_limited(self) -> None:
+        """Mark API as rate-limited until midnight (next calendar day)."""
+        now = datetime.now()
+        tomorrow = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0,
+        )
+        self._rate_limited_until = tomorrow
+        _LOGGER.warning(
+            "API rate-limited — serving cached data until %s",
+            tomorrow.isoformat(),
+        )
 
     async def async_initialize(self) -> None:
         """Initialize all sub-components."""
@@ -135,7 +156,19 @@ class FinanceDashboardManager:
 
         Fetches last N days of transactions, auto-categorizes them,
         and persists to encrypted .storage/ cache.
+
+        If the API returns HTTP 429 (daily quota exhausted), cached
+        data is served and no further API calls are attempted until
+        the next calendar day (midnight local time).
         """
+        # Skip API calls if we're still rate-limited
+        if self.rate_limited_until:
+            _LOGGER.info(
+                "API rate-limited until %s — serving cached transactions",
+                self._rate_limited_until.isoformat(),
+            )
+            return self._transactions
+
         client = await self._async_get_client()
         if not client:
             return []
@@ -184,6 +217,13 @@ class FinanceDashboardManager:
                     len(booked),
                     len(pending),
                 )
+            except RateLimitExceeded:
+                _LOGGER.warning(
+                    "Rate limit hit for account %s — stopping all fetches",
+                    account_id,
+                )
+                self._set_rate_limited()
+                break
             except Exception:
                 _LOGGER.exception(
                     "Failed to fetch transactions for account %s",
@@ -263,6 +303,11 @@ class FinanceDashboardManager:
 
     async def async_get_balance(self) -> dict[str, Any]:
         """Get current balances for all accounts."""
+        # Serve cached balances while rate-limited
+        if self.rate_limited_until:
+            _LOGGER.debug("Rate-limited — serving cached balances")
+            return self._balances
+
         client = await self._async_get_client()
         if not client:
             return {}
@@ -290,6 +335,13 @@ class FinanceDashboardManager:
                     "logo": account.get("logo", ""),
                     "balances": account_balances,
                 }
+            except RateLimitExceeded:
+                _LOGGER.warning(
+                    "Rate limit hit fetching balance for %s — serving cache",
+                    account_id,
+                )
+                self._set_rate_limited()
+                return self._balances
             except Exception:
                 _LOGGER.exception(
                     "Failed to fetch balance for account %s",
@@ -437,6 +489,11 @@ class FinanceDashboardManager:
             "last_refresh": (
                 self._last_refresh.isoformat()
                 if self._last_refresh
+                else None
+            ),
+            "rate_limited_until": (
+                self._rate_limited_until.isoformat()
+                if self.rate_limited_until
                 else None
             ),
         }

--- a/custom_components/finance_dashboard/sensor.py
+++ b/custom_components/finance_dashboard/sensor.py
@@ -271,4 +271,5 @@ class MonthlySummarySensor(
             "household": summary.get("household"),
             "recurring": summary.get("recurring", []),
             "last_refresh": summary.get("last_refresh"),
+            "rate_limited_until": summary.get("rate_limited_until"),
         }

--- a/custom_components/finance_dashboard/translations/en.json
+++ b/custom_components/finance_dashboard/translations/en.json
@@ -2,69 +2,73 @@
   "config": {
     "step": {
       "user": {
-        "title": "GoCardless API Setup",
-        "description": "Enter your GoCardless/Nordigen API credentials.\n\nGet your free API keys at [{gocardless_url}]({gocardless_url}).\n\n**Security:** Your credentials are encrypted and stored locally in Home Assistant.",
+        "title": "Enable Banking Setup",
+        "description": "Enter your Enable Banking API credentials.\n\n**How to get your credentials:**\n1. Go to [{enablebanking_url}/cp/applications]({enablebanking_url}/cp/applications)\n2. Choose **Sandbox** (for testing) or **Production**\n3. Select **Generate in the browser** for the key\n4. Enter an application name (e.g. \"Home Assistant Finance\")\n5. Add your HA redirect URL: `{redirect_url}`\n6. Click **Register** — your private key will download automatically\n7. Copy the **Application ID** from the confirmation page\n\n**Security:** Your credentials are encrypted and stored locally in Home Assistant.\n\nAfter setup, open the **Finance** sidebar panel to connect your bank.",
         "data": {
-          "secret_id": "Secret ID",
-          "secret_key": "Secret Key"
+          "application_id": "Application ID",
+          "private_key_pem": "Private Key (PEM)"
         }
-      },
-      "select_bank": {
-        "title": "Select Your Bank",
-        "description": "Choose your banking institution from {bank_count} available German banks.",
-        "data": {
-          "institution_id": "Bank"
-        }
-      },
-      "authorize": {
-        "title": "Authorize Bank Access",
-        "description": "Click the link below to authorize access to your bank account at **{bank_name}**.\n\n[Open Bank Authorization]({auth_url})\n\nAfter completing the authorization at your bank, return here and click **Submit**."
-      },
-      "assign_accounts": {
-        "title": "Assign Accounts",
-        "description": "Found {account_count} accounts: {account_list}\n\nFor each account, choose whether it is **personal** or **shared**."
       }
     },
     "error": {
-      "missing_credentials": "Please enter both Secret ID and Secret Key.",
-      "invalid_credentials": "Could not connect to GoCardless. Please verify your API credentials.",
+      "missing_credentials": "Please enter both Application ID and Private Key.",
+      "invalid_key_format": "The private key could not be loaded. Make sure you paste the complete PEM content including the -----BEGIN/END PRIVATE KEY----- lines.",
+      "invalid_credentials": "Enable Banking rejected the credentials (HTTP 401/403). Verify that your Application ID matches the private key and the application is activated.",
       "no_institutions": "No banking institutions found for Germany.",
-      "invalid_institution": "Please select a valid bank.",
-      "connection_failed": "Connection to GoCardless failed. Please check your internet connection.",
-      "bank_rejected": "Your bank rejected the authorization. Please try again.",
-      "authorization_expired": "The authorization has expired. Please start over.",
-      "authorization_pending": "Authorization not yet complete. Please finish at your bank and try again.",
-      "no_accounts_linked": "No accounts were linked. Please try the authorization again."
+      "connection_failed": "Connection to Enable Banking failed. Please check your internet connection."
     },
     "abort": {
-      "already_configured": "Finance Dashboard is already configured."
+      "already_configured": "Finance is already configured."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Finance Dashboard Settings",
+        "title": "Finance Settings",
         "data": {
           "refresh_interval_minutes": "Refresh interval (minutes)",
           "split_model": "Budget split model",
           "currency": "Currency",
           "enable_total_balance_sensor": "Enable total balance sensor",
-          "enable_dashboard_panel": "Show sidebar panel"
+          "enable_dashboard_panel": "Show sidebar panel",
+          "transfer_detection_enabled": "Transfer chain detection",
+          "transfer_amount_tolerance": "Amount tolerance (EUR)",
+          "transfer_time_window": "Time window (days)"
+        }
+      }
+    }
+  },
+  "services": {
+    "confirm_transfer_chain": {
+      "name": "Confirm transfer chain",
+      "description": "Confirm or reject a detected transfer chain.",
+      "fields": {
+        "chain_id": {
+          "name": "Chain ID",
+          "description": "UUID of the transfer chain"
+        },
+        "confirmed": {
+          "name": "Confirmed",
+          "description": "True to confirm, false to reject"
         }
       }
     }
   },
   "issues": {
     "restart_required": {
-      "title": "Finance Dashboard Update Available",
+      "title": "Finance Update — Restart Required",
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Restart Required",
-            "description": "Finance Dashboard has been updated to version {version}. A restart is required to apply the update."
+            "title": "Restart Home Assistant",
+            "description": "Finance has been updated to version {version}. Home Assistant must be restarted to apply the update.\n\nClick **Submit** to restart now."
           }
         }
       }
+    },
+    "reconfigure_required": {
+      "title": "Finance: Reconfiguration Required",
+      "description": "Finance has switched from GoCardless to Enable Banking. Please reconfigure with your Enable Banking credentials via Settings > Integrations."
     }
   }
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
@@ -66,9 +66,11 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
             balances = await self._manager.async_get_balance()
             summary = await self._manager.async_get_monthly_summary()
 
+            rate_limited = self._manager.rate_limited_until
             return {
                 "balances": balances,
                 "summary": summary,
+                "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
             }
         except Exception as exc:
             raise UpdateFailed(f"Finance data update failed: {exc}") from exc

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/enablebanking_client.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/enablebanking_client.py
@@ -23,6 +23,12 @@ from typing import Any
 import uuid
 
 import aiohttp
+
+from .const import ENABLEBANKING_RATE_LIMIT_DAILY
+
+
+class RateLimitExceeded(Exception):
+    """Raised when the banking API returns HTTP 429 (daily quota exhausted)."""
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -435,6 +441,12 @@ class EnableBankingClient:
                         resp.status,
                         body[:500],
                     )
+                    # Daily consent quota exhausted — signal callers to
+                    # stop retrying and serve cached data until tomorrow.
+                    if resp.status == 429:
+                        raise RateLimitExceeded(
+                            f"Daily API quota exhausted (HTTP 429): {body[:200]}"
+                        )
                     # Include the API error body in the exception
                     # so callers can surface it to the user
                     raise aiohttp.ClientResponseError(

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -101,6 +101,7 @@ class FdDataProvider extends HTMLElement {
         loading: false,
         error: null,
         lastRefresh: null,
+        rateLimitedUntil: null,
       };
 
       // 1. Read per-account balance sensors
@@ -145,6 +146,7 @@ class FdDataProvider extends HTMLElement {
         data.summary.month = sa.month || data.summary.month;
         data.summary.year = sa.year || data.summary.year;
         data.lastRefresh = sa.last_refresh || null;
+        data.rateLimitedUntil = sa.rate_limited_until || null;
 
         // Household and recurring from entity attrs (added in v0.7.9+)
         if (sa.household) data.household = sa.household;

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
@@ -14,6 +14,7 @@ class FdHeader extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this._lastRefresh = null;
     this._refreshing = false;
+    this._rateLimitedUntil = null;
   }
 
   set lastRefresh(v) {
@@ -23,10 +24,29 @@ class FdHeader extends HTMLElement {
 
   set refreshing(v) {
     this._refreshing = v;
+    this._updateRefreshBtn();
+  }
+
+  set rateLimitedUntil(v) {
+    this._rateLimitedUntil = v;
+    this._updateRefreshBtn();
+  }
+
+  _updateRefreshBtn() {
     const btn = this.shadowRoot.getElementById("refreshBtn");
-    if (btn) {
-      btn.disabled = v;
-      btn.textContent = v ? "Laden\u2026" : "Aktualisieren";
+    if (!btn) return;
+    if (this._rateLimitedUntil && new Date(this._rateLimitedUntil) > new Date()) {
+      btn.disabled = true;
+      btn.textContent = "Morgen verf\u00fcgbar";
+      btn.title = "Tageslimit der Bank-API erreicht. N\u00e4chste Aktualisierung ab morgen.";
+    } else if (this._refreshing) {
+      btn.disabled = true;
+      btn.textContent = "Laden\u2026";
+      btn.title = "";
+    } else {
+      btn.disabled = false;
+      btn.textContent = "Aktualisieren";
+      btn.title = "";
     }
   }
 

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -80,6 +80,12 @@ class FinanceDashboardPanel extends HTMLElement {
     this.shadowRoot.addEventListener("fd-refresh-requested", () => {
       const dp = this.shadowRoot.querySelector("fd-data-provider");
       const header = this.shadowRoot.querySelector("fd-header");
+      // Don't call the API if rate-limited — button should already be disabled,
+      // but guard here as well.
+      if (header && header._rateLimitedUntil &&
+          new Date(header._rateLimitedUntil) > new Date()) {
+        return;
+      }
       if (header) header.refreshing = true;
       if (dp) {
         dp.refresh().finally(() => {
@@ -103,9 +109,12 @@ class FinanceDashboardPanel extends HTMLElement {
     content.className = "";
     content.innerHTML = "";
 
-    // Update header timestamp
+    // Update header timestamp and rate limit state
     const header = this.shadowRoot.querySelector("fd-header");
-    if (header) header.lastRefresh = data.lastRefresh;
+    if (header) {
+      header.lastRefresh = data.lastRefresh;
+      header.rateLimitedUntil = data.rateLimitedUntil;
+    }
 
     // Stats row
     const statsRow = document.createElement("fd-stats-row");

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
@@ -21,6 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN, STORAGE_KEY_TRANSFER_OVERRIDES, STORAGE_VERSION
+from .enablebanking_client import RateLimitExceeded
 from .household import HouseholdMember, HouseholdModel
 from .recurring import detect_recurring
 from .transfer_detector import (
@@ -55,12 +56,32 @@ class FinanceDashboardManager:
         self._transactions: list[dict[str, Any]] = []
         self._balances: dict[str, Any] = {}
         self._last_refresh: datetime | None = None
+        self._rate_limited_until: datetime | None = None
         self._transfer_override_store = Store(
             hass, 1, STORAGE_KEY_TRANSFER_OVERRIDES
         )
         self._transfer_overrides: dict[str, bool] = {}
         self._recurring_patterns: list[dict[str, Any]] = []
         self._previous_balances: dict[str, float] = {}
+
+    @property
+    def rate_limited_until(self) -> datetime | None:
+        """Return the datetime until which the API is rate-limited, or None."""
+        if self._rate_limited_until and datetime.now() < self._rate_limited_until:
+            return self._rate_limited_until
+        return None
+
+    def _set_rate_limited(self) -> None:
+        """Mark API as rate-limited until midnight (next calendar day)."""
+        now = datetime.now()
+        tomorrow = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0,
+        )
+        self._rate_limited_until = tomorrow
+        _LOGGER.warning(
+            "API rate-limited — serving cached data until %s",
+            tomorrow.isoformat(),
+        )
 
     async def async_initialize(self) -> None:
         """Initialize all sub-components."""
@@ -135,7 +156,19 @@ class FinanceDashboardManager:
 
         Fetches last N days of transactions, auto-categorizes them,
         and persists to encrypted .storage/ cache.
+
+        If the API returns HTTP 429 (daily quota exhausted), cached
+        data is served and no further API calls are attempted until
+        the next calendar day (midnight local time).
         """
+        # Skip API calls if we're still rate-limited
+        if self.rate_limited_until:
+            _LOGGER.info(
+                "API rate-limited until %s — serving cached transactions",
+                self._rate_limited_until.isoformat(),
+            )
+            return self._transactions
+
         client = await self._async_get_client()
         if not client:
             return []
@@ -184,6 +217,13 @@ class FinanceDashboardManager:
                     len(booked),
                     len(pending),
                 )
+            except RateLimitExceeded:
+                _LOGGER.warning(
+                    "Rate limit hit for account %s — stopping all fetches",
+                    account_id,
+                )
+                self._set_rate_limited()
+                break
             except Exception:
                 _LOGGER.exception(
                     "Failed to fetch transactions for account %s",
@@ -263,6 +303,11 @@ class FinanceDashboardManager:
 
     async def async_get_balance(self) -> dict[str, Any]:
         """Get current balances for all accounts."""
+        # Serve cached balances while rate-limited
+        if self.rate_limited_until:
+            _LOGGER.debug("Rate-limited — serving cached balances")
+            return self._balances
+
         client = await self._async_get_client()
         if not client:
             return {}
@@ -290,6 +335,13 @@ class FinanceDashboardManager:
                     "logo": account.get("logo", ""),
                     "balances": account_balances,
                 }
+            except RateLimitExceeded:
+                _LOGGER.warning(
+                    "Rate limit hit fetching balance for %s — serving cache",
+                    account_id,
+                )
+                self._set_rate_limited()
+                return self._balances
             except Exception:
                 _LOGGER.exception(
                     "Failed to fetch balance for account %s",
@@ -437,6 +489,11 @@ class FinanceDashboardManager:
             "last_refresh": (
                 self._last_refresh.isoformat()
                 if self._last_refresh
+                else None
+            ),
+            "rate_limited_until": (
+                self._rate_limited_until.isoformat()
+                if self.rate_limited_until
                 else None
             ),
         }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/sensor.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/sensor.py
@@ -271,4 +271,5 @@ class MonthlySummarySensor(
             "household": summary.get("household"),
             "recurring": summary.get("recurring", []),
             "last_refresh": summary.get("last_refresh"),
+            "rate_limited_until": summary.get("rate_limited_until"),
         }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/en.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/en.json
@@ -2,69 +2,73 @@
   "config": {
     "step": {
       "user": {
-        "title": "GoCardless API Setup",
-        "description": "Enter your GoCardless/Nordigen API credentials.\n\nGet your free API keys at [{gocardless_url}]({gocardless_url}).\n\n**Security:** Your credentials are encrypted and stored locally in Home Assistant.",
+        "title": "Enable Banking Setup",
+        "description": "Enter your Enable Banking API credentials.\n\n**How to get your credentials:**\n1. Go to [{enablebanking_url}/cp/applications]({enablebanking_url}/cp/applications)\n2. Choose **Sandbox** (for testing) or **Production**\n3. Select **Generate in the browser** for the key\n4. Enter an application name (e.g. \"Home Assistant Finance\")\n5. Add your HA redirect URL: `{redirect_url}`\n6. Click **Register** — your private key will download automatically\n7. Copy the **Application ID** from the confirmation page\n\n**Security:** Your credentials are encrypted and stored locally in Home Assistant.\n\nAfter setup, open the **Finance** sidebar panel to connect your bank.",
         "data": {
-          "secret_id": "Secret ID",
-          "secret_key": "Secret Key"
+          "application_id": "Application ID",
+          "private_key_pem": "Private Key (PEM)"
         }
-      },
-      "select_bank": {
-        "title": "Select Your Bank",
-        "description": "Choose your banking institution from {bank_count} available German banks.",
-        "data": {
-          "institution_id": "Bank"
-        }
-      },
-      "authorize": {
-        "title": "Authorize Bank Access",
-        "description": "Click the link below to authorize access to your bank account at **{bank_name}**.\n\n[Open Bank Authorization]({auth_url})\n\nAfter completing the authorization at your bank, return here and click **Submit**."
-      },
-      "assign_accounts": {
-        "title": "Assign Accounts",
-        "description": "Found {account_count} accounts: {account_list}\n\nFor each account, choose whether it is **personal** or **shared**."
       }
     },
     "error": {
-      "missing_credentials": "Please enter both Secret ID and Secret Key.",
-      "invalid_credentials": "Could not connect to GoCardless. Please verify your API credentials.",
+      "missing_credentials": "Please enter both Application ID and Private Key.",
+      "invalid_key_format": "The private key could not be loaded. Make sure you paste the complete PEM content including the -----BEGIN/END PRIVATE KEY----- lines.",
+      "invalid_credentials": "Enable Banking rejected the credentials (HTTP 401/403). Verify that your Application ID matches the private key and the application is activated.",
       "no_institutions": "No banking institutions found for Germany.",
-      "invalid_institution": "Please select a valid bank.",
-      "connection_failed": "Connection to GoCardless failed. Please check your internet connection.",
-      "bank_rejected": "Your bank rejected the authorization. Please try again.",
-      "authorization_expired": "The authorization has expired. Please start over.",
-      "authorization_pending": "Authorization not yet complete. Please finish at your bank and try again.",
-      "no_accounts_linked": "No accounts were linked. Please try the authorization again."
+      "connection_failed": "Connection to Enable Banking failed. Please check your internet connection."
     },
     "abort": {
-      "already_configured": "Finance Dashboard is already configured."
+      "already_configured": "Finance is already configured."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Finance Dashboard Settings",
+        "title": "Finance Settings",
         "data": {
           "refresh_interval_minutes": "Refresh interval (minutes)",
           "split_model": "Budget split model",
           "currency": "Currency",
           "enable_total_balance_sensor": "Enable total balance sensor",
-          "enable_dashboard_panel": "Show sidebar panel"
+          "enable_dashboard_panel": "Show sidebar panel",
+          "transfer_detection_enabled": "Transfer chain detection",
+          "transfer_amount_tolerance": "Amount tolerance (EUR)",
+          "transfer_time_window": "Time window (days)"
+        }
+      }
+    }
+  },
+  "services": {
+    "confirm_transfer_chain": {
+      "name": "Confirm transfer chain",
+      "description": "Confirm or reject a detected transfer chain.",
+      "fields": {
+        "chain_id": {
+          "name": "Chain ID",
+          "description": "UUID of the transfer chain"
+        },
+        "confirmed": {
+          "name": "Confirmed",
+          "description": "True to confirm, false to reject"
         }
       }
     }
   },
   "issues": {
     "restart_required": {
-      "title": "Finance Dashboard Update Available",
+      "title": "Finance Update — Restart Required",
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Restart Required",
-            "description": "Finance Dashboard has been updated to version {version}. A restart is required to apply the update."
+            "title": "Restart Home Assistant",
+            "description": "Finance has been updated to version {version}. Home Assistant must be restarted to apply the update.\n\nClick **Submit** to restart now."
           }
         }
       }
+    },
+    "reconfigure_required": {
+      "title": "Finance: Reconfiguration Required",
+      "description": "Finance has switched from GoCardless to Enable Banking. Please reconfigure with your Enable Banking credentials via Settings > Integrations."
     }
   }
 }


### PR DESCRIPTION
## Summary
- **HTTP 429 Rate Limit Handling**: When the Enable Banking API returns a daily quota exceeded error, the integration now caches all data until midnight and disables the refresh button with "Morgen verfügbar" instead of spamming 84+ error log entries
- **Translation Fix**: Synced `translations/en.json` from outdated GoCardless-era placeholders (`{gocardless_url}`) to match current `strings.json` and `de.json` (`{enablebanking_url}` + `{redirect_url}`)

## Test plan
- [ ] Trigger a 429 response from Enable Banking API (or mock it) and verify:
  - Cached balances and transactions continue to display
  - Refresh button shows "Morgen verfügbar" (disabled) with tooltip
  - No further API calls are made until after midnight
  - After midnight, button reverts to "Aktualisieren" and refresh works
- [ ] Verify HA translation validation passes (no placeholder mismatch errors in logs)
- [ ] Verify normal refresh flow still works when not rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)