### PR TITLE
fix(frontend): infinite loading when no entities exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tokens.json
 .pytest_cache/
 htmlcov/
 .coverage
+.playwright-mcp/

--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,12 @@
 # Build Log
 
+## 0.8.1 — 2026-04-02
+Version: 0.8.1
+Branch: claude/competent-payne
+Changes:
+- fix(frontend): prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
+- chore: add .playwright-mcp/ to .gitignore
+
 ## 0.8.0 — 2026-03-28
 Version: 0.8.0
 Branch: claude/compassionate-kowalevski

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,14 @@ All notable changes to the Finance will be documented in this file.
 - Account settings API now persists `person` field for household assignment
 - Monthly summary sensor exposes fixed_costs, variable_costs, household, recurring attributes
 
+## [0.8.1] — 2026-04-02
+
+### Added
+- Chore: add .playwright-mcp/ to .gitignore
+
+### Fixed
+- Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
+
 ### Fixed
 - Add DataUpdateCoordinator — entities no longer call banking API directly
 - Sensor update interval 10 min via coordinator (was ~30 s per entity → rate-limit exhaustion)

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -54,7 +54,8 @@ class FdDataProvider extends HTMLElement {
   _onHassChanged() {
     if (!this._hass) return;
     const hash = this._computeStateHash();
-    if (hash === this._prevStateHash) return;
+    // First call must always trigger rebuild (even with empty hash)
+    if (this._data !== null && hash === this._prevStateHash) return;
     this._prevStateHash = hash;
     this._rebuild();
   }

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 
 
+
+## 0.8.1
+- Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
+- Chore: add .playwright-mcp/ to .gitignore
+
 ## 0.8.0
 - Decompose monolithic panel into 10 web components (fd-data-provider, fd-header, fd-stats-row, fd-stat-card, fd-household-section, fd-person-card, fd-category-section, fd-donut-chart, fd-cost-distribution, fd-recurring-list)
 - Entity-first data strategy — fd-data-provider reads HA sensor/number/select entities, falls back to API for household+recurring

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.8.0"
+version: "0.8.1"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -54,7 +54,8 @@ class FdDataProvider extends HTMLElement {
   _onHassChanged() {
     if (!this._hass) return;
     const hash = this._computeStateHash();
-    if (hash === this._prevStateHash) return;
+    // First call must always trigger rebuild (even with empty hash)
+    if (this._data !== null && hash === this._prevStateHash) return;
     this._prevStateHash = hash;
     this._rebuild();
   }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.8.0"
+  "version": "0.8.1"
 }


### PR DESCRIPTION
## Summary
- Fix data provider initial rebuild never firing when no `fd_` entities exist
- Dashboard no longer stuck on "Lade Finanzdaten..." forever
- Root cause: empty state hash matched initial hash, skipping `_rebuild()`

## Test plan
- [x] Python syntax check passes
- [x] JS syntax check passes
- [x] Verified bug via live Playwright inspection on HA instance