### PR TITLE
fix(core+frontend): dashboard loading + restart notification

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -2,10 +2,11 @@
 
 ## 0.8.1 — 2026-04-02
 Version: 0.8.1
-Branch: claude/competent-payne
+Branch: claude/frosty-hoover
+PR: #59
 Changes:
-- fix(frontend): prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
-- chore: add .playwright-mcp/ to .gitignore
+- fix(frontend): fd-data-provider never called _rebuild when no fd_ entities exist — dashboard stuck on "Lade Finanzdaten..." forever. Added _initialRebuildDone flag to ensure first rebuild always runs.
+- fix(core): restart notification deleted by race condition — async_setup_entry unconditionally cleared restart_required issue before polling timer could detect marker. Now preserves issue when marker file exists and polls immediately on setup.
 
 ## 0.8.0 — 2026-03-28
 Version: 0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,13 +264,9 @@ All notable changes to the Finance will be documented in this file.
 
 ## [0.8.1] — 2026-04-02
 
-### Added
-- Chore: add .playwright-mcp/ to .gitignore
-
 ### Fixed
-- Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
-
-### Fixed
+- Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild
+- Restart notification no longer lost due to race condition in entry setup — preserves issue when marker file exists and polls immediately
 - Add DataUpdateCoordinator — entities no longer call banking API directly
 - Sensor update interval 10 min via coordinator (was ~30 s per entity → rate-limit exhaustion)
 - Panel refresh on connectedCallback + 10-min auto-timer instead of every hass setter

--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -46,8 +46,12 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: FinanceDashboardConfigEntry
 ) -> bool:
     """Set up Finance Dashboard from a config entry."""
-    # Clean up stale restart issues from previous sessions
-    ir.async_delete_issue(hass, DOMAIN, "restart_required")
+    # Only clean up stale restart issues if no pending marker exists
+    marker_path = Path(
+        hass.config.path(".storage/finance_dashboard_restart_needed.json")
+    )
+    if not marker_path.exists():
+        ir.async_delete_issue(hass, DOMAIN, "restart_required")
 
     # Initialize the manager (core business logic)
     from .manager import FinanceDashboardManager
@@ -108,6 +112,9 @@ async def async_setup_entry(
             hass, _poll_restart_marker, timedelta(seconds=60)
         )
     )
+
+    # Fire first poll immediately so the user sees the notification within seconds
+    await _poll_restart_marker(None)
 
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -22,6 +22,7 @@ class FdDataProvider extends HTMLElement {
     this._data = null;
     this._debounceTimer = null;
     this._prevStateHash = "";
+    this._initialRebuildDone = false;
     this._loading = false;
   }
 
@@ -54,8 +55,8 @@ class FdDataProvider extends HTMLElement {
   _onHassChanged() {
     if (!this._hass) return;
     const hash = this._computeStateHash();
-    // First call must always trigger rebuild (even with empty hash)
-    if (this._data !== null && hash === this._prevStateHash) return;
+    if (this._initialRebuildDone && hash === this._prevStateHash) return;
+    this._initialRebuildDone = true;
     this._prevStateHash = hash;
     this._rebuild();
   }

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 
 ## 0.8.1
-- Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
-- Chore: add .playwright-mcp/ to .gitignore
+- Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist
+- Restart notification no longer lost due to race condition in entry setup
 
 ## 0.8.0
 - Decompose monolithic panel into 10 web components (fd-data-provider, fd-header, fd-stats-row, fd-stat-card, fd-household-section, fd-person-card, fd-category-section, fd-donut-chart, fd-cost-distribution, fd-recurring-list)

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -46,8 +46,12 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: FinanceDashboardConfigEntry
 ) -> bool:
     """Set up Finance Dashboard from a config entry."""
-    # Clean up stale restart issues from previous sessions
-    ir.async_delete_issue(hass, DOMAIN, "restart_required")
+    # Only clean up stale restart issues if no pending marker exists
+    marker_path = Path(
+        hass.config.path(".storage/finance_dashboard_restart_needed.json")
+    )
+    if not marker_path.exists():
+        ir.async_delete_issue(hass, DOMAIN, "restart_required")
 
     # Initialize the manager (core business logic)
     from .manager import FinanceDashboardManager
@@ -108,6 +112,9 @@ async def async_setup_entry(
             hass, _poll_restart_marker, timedelta(seconds=60)
         )
     )
+
+    # Fire first poll immediately so the user sees the notification within seconds
+    await _poll_restart_marker(None)
 
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -22,6 +22,7 @@ class FdDataProvider extends HTMLElement {
     this._data = null;
     this._debounceTimer = null;
     this._prevStateHash = "";
+    this._initialRebuildDone = false;
     this._loading = false;
   }
 
@@ -54,8 +55,8 @@ class FdDataProvider extends HTMLElement {
   _onHassChanged() {
     if (!this._hass) return;
     const hash = this._computeStateHash();
-    // First call must always trigger rebuild (even with empty hash)
-    if (this._data !== null && hash === this._prevStateHash) return;
+    if (this._initialRebuildDone && hash === this._prevStateHash) return;
+    this._initialRebuildDone = true;
     this._prevStateHash = hash;
     this._rebuild();
   }


### PR DESCRIPTION
## Summary

- **Dashboard stuck on "Lade Finanzdaten..."**: `fd-data-provider._rebuild()` was never called when no `sensor.fd_*` entities exist, because empty state hash matched empty previous hash. Added `_initialRebuildDone` flag.
- **Missing restart notification**: `async_setup_entry` unconditionally deleted the restart issue before the 60s polling timer could fire. Now preserves the issue when marker file exists + polls immediately on setup.

## Test plan
- [x] Verified dashboard renders with 0 entities (shows 0,00 EUR data)
- [x] Syntax validation (Python + JS)
- [x] Payload sync verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)