### PR TITLE
feat(demo): add full demo mode + manual-only API caching

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,22 @@
 # Build Log
 
+## 0.9.0 — 2026-04-05
+Version: 0.9.0
+Branch: claude/practical-fermi
+PR: (pending)
+Changes:
+- feat(demo): full demo mode with realistic German banking data (3 accounts, ~35 transactions, household split, recurring patterns)
+- feat(demo): toggle via UI button (admin-only), service call, or options flow — persists across HA restarts
+- feat(core): manual-only API refresh — coordinator update_interval=None, data only updates on explicit user action
+- fix(core): initial coordinator refresh now works on config entry reloads (not just first HA start)
+- fix(core): shutdown no longer overwrites real transaction cache when demo mode is active
+- fix(api): AttributeError in DemoToggleView coordinator lookup — null-safe access pattern
+- fix(api): GoCardless reference replaced with Enable Banking in services.yaml
+- fix(coordinator): removed dead COORDINATOR_UPDATE_INTERVAL constant and corrected all docstrings
+- feat(frontend): demo toggle button with DEMO badge, aria-pressed accessibility, mobile breakpoint
+- fix(frontend): rapid-click guard and loading state for demo API calls
+- fix(frontend): demoMode flag propagated in all data events for consistent UI state
+
 ## 0.8.1 — 2026-04-02
 Version: 0.8.1
 Branch: claude/frosty-hoover, claude/competent-payne

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,23 @@ All notable changes to the Finance will be documented in this file.
 ### Added
 - Chore: add .playwright-mcp/ to .gitignore
 
+## [0.9.0] — 2026-04-05
+
+### Added
+- Full demo mode with realistic German banking data (3 accounts, ~35 transactions, household split, recurring patterns)
+- Toggle via UI button (admin-only), service call, or options flow — persists across HA restarts
+- Manual-only API refresh — coordinator update_interval=None, data only updates on explicit user action
+- Demo toggle button with DEMO badge, aria-pressed accessibility, mobile breakpoint
+
+### Fixed
+- Initial coordinator refresh now works on config entry reloads (not just first HA start)
+- Shutdown no longer overwrites real transaction cache when demo mode is active
+- AttributeError in DemoToggleView coordinator lookup — null-safe access pattern
+- GoCardless reference replaced with Enable Banking in services.yaml
+- Removed dead COORDINATOR_UPDATE_INTERVAL constant and corrected all docstrings
+- Rapid-click guard and loading state for demo API calls
+- DemoMode flag propagated in all data events for consistent UI state
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DOMAIN,
+    SERVICE_TOGGLE_DEMO,
     STORAGE_KEY_AUDIT,
     STORAGE_VERSION,
 )
@@ -64,6 +65,10 @@ async def async_setup_entry(
     from .coordinator import FinanceDashboardCoordinator
 
     coordinator = FinanceDashboardCoordinator(hass, manager)
+
+    # Initialize demo mode from options
+    if entry.options.get("demo_mode", False):
+        manager.set_demo_mode(True)
 
     hass.data[DOMAIN][entry.entry_id] = manager
     hass.data[DOMAIN][f"{entry.entry_id}_coordinator"] = coordinator
@@ -119,18 +124,24 @@ async def async_setup_entry(
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Kick off the first coordinator refresh once HA is fully started.
-    # This populates entities with live data immediately without blocking startup.
-    if entry.data.get("configured"):
-        async def _initial_refresh(_event=None) -> None:
+    # Kick off the first coordinator refresh.
+    # Uses async_create_task so it works both on initial HA start AND
+    # on config entry reloads (homeassistant_started only fires once).
+    if entry.data.get("configured") or manager.demo_mode:
+        async def _initial_refresh() -> None:
             try:
                 await coordinator.async_refresh()
                 _LOGGER.info("Initial coordinator refresh completed")
             except Exception:
                 _LOGGER.exception("Initial coordinator refresh failed")
 
-
-        hass.bus.async_listen_once("homeassistant_started", _initial_refresh)
+        if hass.is_running:
+            hass.async_create_task(_initial_refresh())
+        else:
+            hass.bus.async_listen_once(
+                "homeassistant_started",
+                lambda _event: hass.async_create_task(_initial_refresh()),
+            )
 
     _LOGGER.info("Finance Dashboard v%s loaded", entry.version)
     return True
@@ -199,6 +210,11 @@ async def _async_register_services(
         )
         return {"path": path}
 
+    async def handle_toggle_demo(call) -> None:
+        enabled = not manager.demo_mode
+        manager.set_demo_mode(enabled)
+        await coordinator.async_refresh()
+
     hass.services.async_register(
         DOMAIN, SERVICE_REFRESH_ACCOUNTS, handle_refresh_accounts
     )
@@ -219,4 +235,7 @@ async def _async_register_services(
     )
     hass.services.async_register(
         DOMAIN, SERVICE_EXPORT_CSV, handle_export_csv
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_TOGGLE_DEMO, handle_toggle_demo
     )

--- a/custom_components/finance_dashboard/api.py
+++ b/custom_components/finance_dashboard/api.py
@@ -42,6 +42,8 @@ async def async_register_api(hass: HomeAssistant) -> None:
     hass.http.register_view(FinanceDashboardSetupUsersView())
     hass.http.register_view(FinanceDashboardSetupUpdateAccountsView())
     hass.http.register_view(FinanceDashboardTransferChainsView())
+    hass.http.register_view(FinanceDashboardDemoToggleView())
+    hass.http.register_view(FinanceDashboardDemoDataView())
     _LOGGER.debug("Finance API endpoints registered")
 
 
@@ -989,6 +991,75 @@ class FinanceDashboardTransferChainsView(HomeAssistantView):
         return self.json(
             {"success": True, "chain_id": chain_id}
         )
+
+
+class FinanceDashboardDemoToggleView(HomeAssistantView):
+    """Toggle demo mode on/off (admin only)."""
+
+    url = f"/api/{DOMAIN}/demo/toggle"
+    name = f"api:{DOMAIN}:demo_toggle"
+    requires_auth = True
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Toggle demo mode and return new state."""
+        hass = request.app["hass"]
+
+        user = request.get("hass_user")
+        is_admin = user and user.is_admin if user else False
+        if not is_admin:
+            return self.json(
+                {"error": "Admin access required"},
+                status_code=403,
+            )
+
+        manager = _get_manager(hass)
+
+        if manager:
+            enabled = not manager.demo_mode
+            manager.set_demo_mode(enabled)
+
+            # Persist to entry.options so demo survives HA restarts
+            entry = hass.data.get(DOMAIN, {}).get("entry")
+            if entry:
+                new_options = {**entry.options, "demo_mode": enabled}
+                hass.config_entries.async_update_entry(
+                    entry, options=new_options
+                )
+
+            # Trigger coordinator refresh so entities update
+            domain_data = hass.data.get(DOMAIN, {})
+            coordinator = (
+                domain_data.get(f"{entry.entry_id}_coordinator")
+                if entry
+                else None
+            )
+            if coordinator:
+                await coordinator.async_refresh()
+            return self.json({"demo_mode": enabled})
+
+        # No manager — toggle in hass.data for API-only demo
+        current = hass.data.get(DOMAIN, {}).get("demo_mode", False)
+        hass.data.setdefault(DOMAIN, {})["demo_mode"] = not current
+        return self.json({"demo_mode": not current})
+
+
+class FinanceDashboardDemoDataView(HomeAssistantView):
+    """Return demo data — works with or without a config entry."""
+
+    url = f"/api/{DOMAIN}/demo/data"
+    name = f"api:{DOMAIN}:demo_data"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return a fresh demo dataset."""
+        from .demo import generate_demo_data
+
+        data = generate_demo_data()
+        # Strip internal keys
+        data.pop("_demo_accounts", None)
+        data.pop("_demo_transactions", None)
+        data.pop("_demo_balances", None)
+        return self.json(data)
 
 
 class FinanceDashboardSummaryView(HomeAssistantView):

--- a/custom_components/finance_dashboard/config_flow.py
+++ b/custom_components/finance_dashboard/config_flow.py
@@ -253,6 +253,12 @@ class FinanceDashboardOptionsFlow(OptionsFlow):
                             "enable_dashboard_panel", True
                         ),
                     ): bool,
+                    vol.Optional(
+                        "demo_mode",
+                        default=self.config_entry.options.get(
+                            "demo_mode", False
+                        ),
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -123,3 +123,6 @@ REFUND_KEYWORDS = [
 
 # Household model
 DEFAULT_SPLIT_MODEL = "proportional"  # proportional, equal, custom
+
+# Demo mode
+SERVICE_TOGGLE_DEMO = "toggle_demo"

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.8.1"
+VERSION = "0.9.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/coordinator.py
+++ b/custom_components/finance_dashboard/coordinator.py
@@ -2,7 +2,7 @@
 
 Centralises all Enable Banking API calls so that:
 - No entity ever calls the API directly
-- All updates happen on a fixed 10-minute schedule
+- Updates only happen on manual refresh (service call or UI button)
 - Rate limits are respected (transactions refreshed only when stale)
 - A single coordinator failure does not orphan individual entities
 """
@@ -19,15 +19,12 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-# Balance + summary: every 10 minutes
-COORDINATOR_UPDATE_INTERVAL = timedelta(minutes=10)
-
 # Only re-fetch raw transactions if cache is older than 6 hours
 TRANSACTION_REFRESH_STALENESS = timedelta(hours=6)
 
 
 class FinanceDashboardCoordinator(DataUpdateCoordinator):
-    """Fetch balances and monthly summary on a fixed schedule.
+    """Fetch balances and monthly summary on manual refresh only.
 
     Entities read from coordinator.data — they never call the banking
     API themselves.  Structure of coordinator.data:
@@ -38,18 +35,23 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
     """
 
     def __init__(self, hass: HomeAssistant, manager) -> None:
-        """Initialise coordinator with a reference to the manager."""
+        """Initialise coordinator with a reference to the manager.
+
+        update_interval is None — API calls only happen on manual refresh
+        (service call or UI button). Entities receive cached data from
+        the initial startup refresh and subsequent manual refreshes.
+        """
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=COORDINATOR_UPDATE_INTERVAL,
+            update_interval=None,
         )
         self._manager = manager
         self._first_update = True
 
     async def _async_update_data(self) -> dict:
-        """Called by HA every 10 minutes (and on demand via async_refresh)."""
+        """Called on demand via async_refresh() (manual refresh only)."""
         try:
             # Refresh raw transactions only when the cache is stale.
             # Balance calls happen on every cycle; transaction fetches are

--- a/custom_components/finance_dashboard/demo.py
+++ b/custom_components/finance_dashboard/demo.py
@@ -1,0 +1,400 @@
+"""Demo data generator for Finance Dashboard.
+
+Generates realistic German banking data for demo/testing purposes.
+All data is synthetic — no real financial information.
+
+Each call to generate_demo_data() produces a complete, randomized dataset
+that matches the exact shape the frontend expects (unified data object).
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Demo bank accounts
+# ---------------------------------------------------------------------------
+
+DEMO_ACCOUNTS_CONFIG: list[dict[str, Any]] = [
+    {
+        "id": "demo-sparkasse-anna",
+        "iban": "DE89370400440532013000",
+        "name": "Girokonto",
+        "custom_name": "Anna Sparkasse",
+        "institution": "Sparkasse",
+        "institution_id": "SPARKASSE_DE",
+        "logo": "",
+        "currency": "EUR",
+        "type": "personal",
+        "person": "Anna",
+        "ha_users": [],
+    },
+    {
+        "id": "demo-dkb-max",
+        "iban": "DE27100110012621953188",
+        "name": "Girokonto",
+        "custom_name": "Max DKB",
+        "institution": "DKB",
+        "institution_id": "DKB_DE",
+        "logo": "",
+        "currency": "EUR",
+        "type": "personal",
+        "person": "Max",
+        "ha_users": [],
+    },
+    {
+        "id": "demo-ing-shared",
+        "iban": "DE60500105175418543281",
+        "name": "Gemeinschaftskonto",
+        "custom_name": "Haushaltskonto",
+        "institution": "ING",
+        "institution_id": "ING_DE",
+        "logo": "",
+        "currency": "EUR",
+        "type": "shared",
+        "person": "",
+        "ha_users": [],
+    },
+]
+
+# Base balances per account (randomized ±15%)
+_BASE_BALANCES = {
+    "demo-sparkasse-anna": 3250.00,
+    "demo-dkb-max": 2180.00,
+    "demo-ing-shared": 1520.00,
+}
+
+# ---------------------------------------------------------------------------
+# Transaction templates — amounts are jittered at generation time
+# ---------------------------------------------------------------------------
+
+_TRANSACTION_TEMPLATES: list[dict[str, Any]] = [
+    # --- Shared account (ING) ---
+    {"creditor": "Hausverwaltung GmbH", "desc": "Miete {month_name} {year}", "base": -1150.0, "cat": "housing", "day": 1, "acc": "demo-ing-shared"},
+    {"creditor": "Stadtwerke München", "desc": "Strom Abschlag", "base": -85.0, "cat": "utilities", "day": 3, "acc": "demo-ing-shared"},
+    {"creditor": "Telekom", "desc": "Festnetz + Internet", "base": -44.95, "cat": "utilities", "day": 5, "acc": "demo-ing-shared"},
+    {"creditor": "Allianz Versicherung", "desc": "Haftpflichtversicherung", "base": -12.50, "cat": "insurance", "day": 1, "acc": "demo-ing-shared"},
+    {"creditor": "GEZ", "desc": "Rundfunkbeitrag", "base": -18.36, "cat": "utilities", "day": 1, "acc": "demo-ing-shared"},
+    {"creditor": "REWE Markt", "desc": "REWE Großeinkauf", "base": -89.45, "cat": "food", "day": 4, "acc": "demo-ing-shared"},
+    {"creditor": "HelloFresh", "desc": "HelloFresh Kochbox KW14", "base": -49.99, "cat": "food", "day": 8, "acc": "demo-ing-shared"},
+
+    # --- Anna (Sparkasse) ---
+    {"creditor": "Arbeitgeber GmbH", "desc": "Gehalt {month_name}", "base": 3250.0, "cat": "income", "day": 25, "acc": "demo-sparkasse-anna"},
+    {"creditor": "REWE Markt", "desc": "REWE SAGT DANKE 4823", "base": -47.83, "cat": "food", "day": 2, "acc": "demo-sparkasse-anna"},
+    {"creditor": "EDEKA", "desc": "EDEKA Einkauf", "base": -32.15, "cat": "food", "day": 5, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Netflix", "desc": "Netflix Abo", "base": -13.99, "cat": "subscriptions", "day": 8, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Spotify", "desc": "Spotify Premium Family", "base": -17.99, "cat": "subscriptions", "day": 1, "acc": "demo-sparkasse-anna"},
+    {"creditor": "DB Vertrieb", "desc": "Deutschlandticket", "base": -49.00, "cat": "transport", "day": 1, "acc": "demo-sparkasse-anna"},
+    {"creditor": "ALDI", "desc": "ALDI SÜD Filiale 2847", "base": -28.47, "cat": "food", "day": 10, "acc": "demo-sparkasse-anna"},
+    {"creditor": "dm-drogerie", "desc": "dm Drogeriemarkt", "base": -15.99, "cat": "other", "day": 7, "acc": "demo-sparkasse-anna"},
+    {"creditor": "REWE Markt", "desc": "REWE SAGT DANKE 5121", "base": -52.30, "cat": "food", "day": 12, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Lieferando", "desc": "Lieferando Bestellung", "base": -24.90, "cat": "food", "day": 14, "acc": "demo-sparkasse-anna"},
+    {"creditor": "HUK-COBURG", "desc": "KFZ Versicherung", "base": -45.80, "cat": "insurance", "day": 1, "acc": "demo-sparkasse-anna"},
+    {"creditor": "LIDL", "desc": "LIDL SAGT DANKE", "base": -19.62, "cat": "food", "day": 16, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Rossmann", "desc": "Rossmann Filiale", "base": -8.49, "cat": "other", "day": 18, "acc": "demo-sparkasse-anna"},
+
+    # --- Max (DKB) ---
+    {"creditor": "Tech AG", "desc": "Gehalt {month_name}", "base": 2850.0, "cat": "income", "day": 27, "acc": "demo-dkb-max"},
+    {"creditor": "REWE Markt", "desc": "REWE Einkauf", "base": -38.92, "cat": "food", "day": 3, "acc": "demo-dkb-max"},
+    {"creditor": "Lidl", "desc": "LIDL DIENSTL", "base": -22.47, "cat": "food", "day": 6, "acc": "demo-dkb-max"},
+    {"creditor": "Disney Plus", "desc": "Disney+ Abo", "base": -8.99, "cat": "subscriptions", "day": 15, "acc": "demo-dkb-max"},
+    {"creditor": "Xbox", "desc": "Xbox Game Pass Ultimate", "base": -14.99, "cat": "subscriptions", "day": 10, "acc": "demo-dkb-max"},
+    {"creditor": "Shell", "desc": "Shell Tankstelle München", "base": -65.40, "cat": "transport", "day": 8, "acc": "demo-dkb-max"},
+    {"creditor": "Amazon", "desc": "Amazon.de Bestellung", "base": -34.99, "cat": "other", "day": 11, "acc": "demo-dkb-max"},
+    {"creditor": "EDEKA", "desc": "EDEKA Center", "base": -41.23, "cat": "food", "day": 9, "acc": "demo-dkb-max"},
+    {"creditor": "McFIT", "desc": "McFIT Mitgliedschaft", "base": -29.90, "cat": "other", "day": 1, "acc": "demo-dkb-max"},
+    {"creditor": "ARAL", "desc": "ARAL Tankstelle", "base": -58.20, "cat": "transport", "day": 15, "acc": "demo-dkb-max"},
+    {"creditor": "HypoVereinsbank", "desc": "Autokredit Rate 48/60", "base": -285.00, "cat": "loans", "day": 5, "acc": "demo-dkb-max"},
+    {"creditor": "Barmer", "desc": "Zusatzversicherung Zahn", "base": -28.50, "cat": "insurance", "day": 1, "acc": "demo-dkb-max"},
+    {"creditor": "Google", "desc": "Google One 200 GB", "base": -2.99, "cat": "subscriptions", "day": 12, "acc": "demo-dkb-max"},
+    {"creditor": "REWE Markt", "desc": "REWE Abend-Einkauf", "base": -31.78, "cat": "food", "day": 17, "acc": "demo-dkb-max"},
+]
+
+# Recurring patterns for demo
+_RECURRING_TEMPLATES: list[dict[str, Any]] = [
+    {"creditor": "Hausverwaltung GmbH", "average_amount": -1150.0, "frequency": "monthly", "category": "housing", "occurrences": 12, "expected_day": 1},
+    {"creditor": "Stadtwerke München", "average_amount": -85.0, "frequency": "monthly", "category": "utilities", "occurrences": 12, "expected_day": 3},
+    {"creditor": "Telekom", "average_amount": -44.95, "frequency": "monthly", "category": "utilities", "occurrences": 12, "expected_day": 5},
+    {"creditor": "Netflix", "average_amount": -13.99, "frequency": "monthly", "category": "subscriptions", "occurrences": 8, "expected_day": 8},
+    {"creditor": "Spotify", "average_amount": -17.99, "frequency": "monthly", "category": "subscriptions", "occurrences": 11, "expected_day": 1},
+    {"creditor": "DB Vertrieb", "average_amount": -49.00, "frequency": "monthly", "category": "transport", "occurrences": 10, "expected_day": 1},
+    {"creditor": "HypoVereinsbank", "average_amount": -285.00, "frequency": "monthly", "category": "loans", "occurrences": 12, "expected_day": 5},
+    {"creditor": "HelloFresh", "average_amount": -49.99, "frequency": "monthly", "category": "food", "occurrences": 6, "expected_day": 8},
+]
+
+# Month names for German formatting
+_MONTH_NAMES = [
+    "Januar", "Februar", "März", "April", "Mai", "Juni",
+    "Juli", "August", "September", "Oktober", "November", "Dezember",
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_demo_data() -> dict[str, Any]:
+    """Generate a complete demo dataset matching the frontend unified data shape.
+
+    Returns a dict with keys: accounts, totalBalance, accountCount, summary,
+    budgets, splitModel, household, recurring, loading, error, lastRefresh,
+    rateLimitedUntil, _demo_accounts, _demo_transactions, _demo_balances.
+
+    The _demo_* keys are internal — used by the manager to populate entities.
+    """
+    rng = random.Random()
+    now = datetime.now()
+    month = now.month
+    year = now.year
+    month_name = _MONTH_NAMES[month - 1]
+
+    accounts = _build_accounts()
+    transactions = _build_transactions(rng, month, year, month_name)
+    balances = _build_balances(rng, accounts)
+
+    # Compute summary from transactions
+    category_totals: dict[str, float] = {}
+    total_income = 0.0
+    total_expenses = 0.0
+
+    for txn in transactions:
+        amount = float(txn["transactionAmount"]["amount"])
+        cat = txn.get("category", "other")
+        if amount > 0:
+            total_income += amount
+        else:
+            total_expenses += abs(amount)
+        category_totals[cat] = category_totals.get(cat, 0) + amount
+
+    fixed_cats = {"housing", "loans", "utilities", "insurance"}
+    fixed_total = sum(abs(category_totals.get(c, 0)) for c in fixed_cats)
+    variable_total = total_expenses - fixed_total
+
+    # Build household data
+    household = _build_household(rng, transactions, total_expenses)
+
+    # Build frontend account list
+    fe_accounts = []
+    total_balance = 0.0
+    for acc in accounts:
+        acc_id = acc["id"]
+        bal_data = balances.get(acc_id, {})
+        raw_bals = bal_data.get("balances", [])
+        bal_val = 0.0
+        if raw_bals:
+            bal_val = float(raw_bals[0].get("balanceAmount", {}).get("amount", 0))
+        iban = acc.get("iban", "")
+        fe_accounts.append({
+            "entityId": f"sensor.fd_demo_{acc_id.replace('-', '_')}",
+            "name": acc.get("custom_name") or acc.get("name", ""),
+            "institution": acc.get("institution", ""),
+            "balance": bal_val,
+            "ibanMasked": f"****{iban[-4:]}" if len(iban) >= 4 else "****",
+            "currency": acc.get("currency", "EUR"),
+            "person": acc.get("person", ""),
+        })
+        total_balance += bal_val
+
+    # Budget limits (demo defaults)
+    budgets = {
+        "housing": 1200.0,
+        "food": 600.0,
+        "transport": 200.0,
+        "subscriptions": 100.0,
+        "insurance": 150.0,
+        "utilities": 200.0,
+        "loans": 300.0,
+        "other": 200.0,
+    }
+
+    return {
+        # Frontend unified data shape
+        "accounts": fe_accounts,
+        "totalBalance": round(total_balance, 2),
+        "accountCount": len(fe_accounts),
+        "summary": {
+            "totalIncome": round(total_income, 2),
+            "totalExpenses": round(total_expenses, 2),
+            "balance": round(total_income - total_expenses, 2),
+            "categories": {k: round(v, 2) for k, v in category_totals.items()},
+            "transactionCount": len(transactions),
+            "fixedCosts": round(fixed_total, 2),
+            "variableCosts": round(variable_total, 2),
+            "month": month,
+            "year": year,
+        },
+        "budgets": budgets,
+        "splitModel": "proportional",
+        "household": household,
+        "recurring": _RECURRING_TEMPLATES[:8],
+        "loading": False,
+        "error": None,
+        "lastRefresh": now.isoformat(),
+        "rateLimitedUntil": None,
+        # Internal keys for manager/coordinator
+        "_demo_accounts": accounts,
+        "_demo_transactions": transactions,
+        "_demo_balances": balances,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal builders
+# ---------------------------------------------------------------------------
+
+
+def _build_accounts() -> list[dict[str, Any]]:
+    """Return a deep copy of demo accounts."""
+    return [dict(a) for a in DEMO_ACCOUNTS_CONFIG]
+
+
+def _build_transactions(
+    rng: random.Random,
+    month: int,
+    year: int,
+    month_name: str,
+) -> list[dict[str, Any]]:
+    """Generate demo transactions for the given month."""
+    today = datetime.now().day
+    transactions: list[dict[str, Any]] = []
+
+    # Build account lookup for tagging
+    acc_map = {a["id"]: a for a in DEMO_ACCOUNTS_CONFIG}
+
+    for i, tpl in enumerate(_TRANSACTION_TEMPLATES):
+        day = tpl["day"]
+        # Skip future dates within the month (including future salaries)
+        if day > today:
+            continue
+
+        # Jitter amount by ±8% (except fixed amounts like rent, salary)
+        base = tpl["base"]
+        if abs(base) > 100 and tpl["cat"] not in ("income", "housing", "loans"):
+            jitter = rng.uniform(-0.08, 0.08)
+            amount = round(base * (1 + jitter), 2)
+        elif abs(base) < 100:
+            jitter = rng.uniform(-0.12, 0.12)
+            amount = round(base * (1 + jitter), 2)
+        else:
+            amount = base
+
+        booking_date = f"{year}-{month:02d}-{day:02d}"
+        desc = tpl["desc"].format(month_name=month_name, year=year)
+        acc_id = tpl["acc"]
+        acc = acc_map.get(acc_id, {})
+
+        transactions.append({
+            "transactionId": f"demo-{i:04d}-{rng.randint(1000, 9999)}",
+            "bookingDate": booking_date,
+            "transactionAmount": {
+                "amount": str(amount),
+                "currency": "EUR",
+            },
+            "creditorName": tpl["creditor"],
+            "remittanceInformationUnstructured": desc,
+            "category": tpl["cat"],
+            "_account_id": acc_id,
+            "_account_name": acc.get("custom_name") or acc.get("name", ""),
+            "_account_type": acc.get("type", "personal"),
+            "_account_person": acc.get("person", ""),
+            "_account_ha_users": [],
+            "_status": "booked",
+        })
+
+    # Sort newest first
+    transactions.sort(key=lambda t: t["bookingDate"], reverse=True)
+    return transactions
+
+
+def _build_balances(
+    rng: random.Random,
+    accounts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Generate demo balance data per account."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    balances: dict[str, Any] = {}
+
+    for acc in accounts:
+        acc_id = acc["id"]
+        base = _BASE_BALANCES.get(acc_id, 1000.0)
+        amount = round(base * rng.uniform(0.85, 1.15), 2)
+        iban = acc.get("iban", "")
+
+        balances[acc_id] = {
+            "account_name": acc.get("custom_name") or acc.get("name", ""),
+            "iban": iban,
+            "iban_masked": f"****{iban[-4:]}" if len(iban) >= 4 else "****",
+            "institution": acc.get("institution", ""),
+            "logo": acc.get("logo", ""),
+            "balances": [
+                {
+                    "balanceType": "closingBooked",
+                    "balanceAmount": {
+                        "amount": str(amount),
+                        "currency": "EUR",
+                    },
+                    "referenceDate": today,
+                }
+            ],
+        }
+
+    return balances
+
+
+def _build_household(
+    rng: random.Random,
+    transactions: list[dict[str, Any]],
+    total_expenses: float,
+) -> dict[str, Any]:
+    """Build household split data from demo transactions."""
+    persons: dict[str, dict[str, float]] = {}
+    shared_costs = 0.0
+
+    for txn in transactions:
+        amount = float(txn["transactionAmount"]["amount"])
+        acc_type = txn.get("_account_type", "personal")
+        person = txn.get("_account_person", "")
+
+        if acc_type == "shared":
+            if amount < 0:
+                shared_costs += abs(amount)
+        elif person:
+            if person not in persons:
+                persons[person] = {"income": 0.0, "individual_costs": 0.0}
+            if amount > 0:
+                persons[person]["income"] += amount
+            else:
+                persons[person]["individual_costs"] += abs(amount)
+
+    if not persons:
+        return None
+
+    # Calculate proportional split
+    total_income = sum(p["income"] for p in persons.values())
+    members = []
+    for name, data in persons.items():
+        ratio = data["income"] / total_income if total_income > 0 else 0.5
+        share = shared_costs * ratio
+        spielgeld = data["income"] - data["individual_costs"] - share
+
+        members.append({
+            "person": name,
+            "gross_income": round(data["income"], 2),
+            "net_income": round(data["income"], 2),
+            "income_ratio": round(ratio * 100, 1),
+            "shared_costs_share": round(share, 2),
+            "individual_costs": round(data["individual_costs"], 2),
+            "spielgeld": round(spielgeld, 2),
+            "bonus_amount": 0.0,
+        })
+
+    return {
+        "members": members,
+        "split_model": "proportional",
+        "remainder_mode": "none",
+        "total_shared_costs": round(shared_costs, 2),
+    }

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -24,22 +24,85 @@ class FdDataProvider extends HTMLElement {
     this._prevStateHash = "";
     this._initialRebuildDone = false;
     this._loading = false;
+    this._demoMode = false;
+    this._demoToggling = false;
   }
 
   get data() {
     return this._data;
   }
 
+  get demoMode() {
+    return this._demoMode;
+  }
+
   set hass(hass) {
     this._hass = hass;
+    // In demo mode, don't watch entity changes
+    if (this._demoMode) return;
     // Debounce: hass changes many times per second
     clearTimeout(this._debounceTimer);
     this._debounceTimer = setTimeout(() => this._onHassChanged(), DEBOUNCE_MS);
   }
 
+  /** Toggle demo mode — fetches demo data from API. Guarded against rapid clicks. */
+  async toggleDemo() {
+    if (!this._hass || this._demoToggling) return this._demoMode;
+    this._demoToggling = true;
+    try {
+      const result = await this._hass.callApi("POST", `${DOMAIN}/demo/toggle`);
+      this._demoMode = result.demo_mode;
+      if (this._demoMode) {
+        await this._loadDemoData();
+      } else {
+        // Revert to entity-based data
+        this._prevStateHash = "";
+        await this._rebuild();
+      }
+      return this._demoMode;
+    } catch (e) {
+      console.error("fd-data-provider: demo toggle failed:", e);
+      return this._demoMode;
+    } finally {
+      this._demoToggling = false;
+    }
+  }
+
+  /** Load demo data from the API endpoint. */
+  async _loadDemoData() {
+    if (!this._hass) return;
+    // Dispatch loading state
+    this.dispatchEvent(new CustomEvent("fd-data-updated", {
+      detail: { loading: true, demoMode: true },
+      bubbles: true,
+      composed: true,
+    }));
+    try {
+      const data = await this._hass.callApi("GET", `${DOMAIN}/demo/data`);
+      this._data = data;
+      this.dispatchEvent(new CustomEvent("fd-data-updated", {
+        detail: { ...data, demoMode: true },
+        bubbles: true,
+        composed: true,
+      }));
+    } catch (e) {
+      console.error("fd-data-provider: demo data fetch failed:", e);
+      this.dispatchEvent(new CustomEvent("fd-data-updated", {
+        detail: { error: "Demo-Daten konnten nicht geladen werden", demoMode: true },
+        bubbles: true,
+        composed: true,
+      }));
+    }
+  }
+
   /** Trigger a full data rebuild (manual refresh). */
   async refresh() {
     if (!this._hass) return;
+    if (this._demoMode) {
+      // In demo mode, just regenerate demo data
+      await this._loadDemoData();
+      return;
+    }
     // Ask HA to refresh transactions, which triggers coordinator update
     try {
       await this._hass.callService(DOMAIN, "refresh_transactions");
@@ -190,6 +253,7 @@ class FdDataProvider extends HTMLElement {
       }
 
       this._data = data;
+      data.demoMode = this._demoMode;
       this.dispatchEvent(new CustomEvent("fd-data-updated", {
         detail: data,
         bubbles: true,

--- a/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/custom_components/finance_dashboard/frontend/fd-header.js
@@ -15,6 +15,7 @@ class FdHeader extends HTMLElement {
     this._lastRefresh = null;
     this._refreshing = false;
     this._rateLimitedUntil = null;
+    this._demoMode = false;
   }
 
   set lastRefresh(v) {
@@ -30,6 +31,11 @@ class FdHeader extends HTMLElement {
   set rateLimitedUntil(v) {
     this._rateLimitedUntil = v;
     this._updateRefreshBtn();
+  }
+
+  set demoMode(v) {
+    this._demoMode = v;
+    this._updateDemoBtn();
   }
 
   _updateRefreshBtn() {
@@ -54,6 +60,22 @@ class FdHeader extends HTMLElement {
     this._render();
   }
 
+  _updateDemoBtn() {
+    const btn = this.shadowRoot.getElementById("demoBtn");
+    const badge = this.shadowRoot.getElementById("demoBadge");
+    if (!btn) return;
+    btn.setAttribute("aria-pressed", String(this._demoMode));
+    if (this._demoMode) {
+      btn.textContent = "Demo aus";
+      btn.classList.add("btn-demo-active");
+      if (badge) badge.style.display = "inline-block";
+    } else {
+      btn.textContent = "Demo";
+      btn.classList.remove("btn-demo-active");
+      if (badge) badge.style.display = "none";
+    }
+  }
+
   _render() {
     const monthNames = ["Jan", "Feb", "M\u00e4r", "Apr", "Mai", "Jun",
       "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"];
@@ -69,6 +91,7 @@ class FdHeader extends HTMLElement {
   --tx: var(--primary-text-color, #e0e0e0);
   --tx2: var(--secondary-text-color, #9898a8);
   --ac: var(--accent-color, #4ecca3);
+  --demo: #f39c12;
   display: block;
   margin-bottom: 24px;
 }
@@ -77,11 +100,27 @@ class FdHeader extends HTMLElement {
   justify-content: space-between;
   align-items: center;
 }
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 h1 {
   font-size: 24px;
   font-weight: 700;
   margin: 0;
   font-family: 'Segoe UI', system-ui, sans-serif;
+}
+.demo-badge {
+  display: none;
+  padding: 3px 10px;
+  border-radius: 6px;
+  background: var(--demo);
+  color: #0a0a0f;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
 }
 .right {
   display: flex;
@@ -110,11 +149,36 @@ h1 {
   border-color: var(--ac);
   font-weight: 600;
 }
+.btn-demo {
+  border-color: var(--demo);
+  color: var(--demo);
+}
+.btn-demo:hover {
+  background: rgba(243, 156, 18, 0.1);
+}
+.btn-demo-active {
+  background: var(--demo);
+  color: #0a0a0f;
+  font-weight: 600;
+}
+.btn-demo-active:hover {
+  background: #e67e22;
+}
+@media (max-width: 600px) {
+  .hdr { flex-wrap: wrap; gap: 10px; }
+  .right { width: 100%; justify-content: flex-end; }
+  h1 { font-size: 20px; }
+  .btn { padding: 6px 10px; font-size: 12px; }
+}
 </style>
 <div class="hdr">
-  <h1>Finance Dashboard</h1>
+  <div class="title-row">
+    <h1>Finance Dashboard</h1>
+    <span class="demo-badge" id="demoBadge">DEMO</span>
+  </div>
   <div class="right">
     <span class="ts" id="ts"></span>
+    <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
   </div>
@@ -128,7 +192,16 @@ h1 {
         }));
       });
 
+    this.shadowRoot.getElementById("demoBtn")
+      .addEventListener("click", () => {
+        this.dispatchEvent(new CustomEvent("fd-demo-toggle", {
+          bubbles: true,
+          composed: true,
+        }));
+      });
+
     this._updateTimestamp();
+    this._updateDemoBtn();
   }
 
   _updateTimestamp() {

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -93,6 +93,16 @@ class FinanceDashboardPanel extends HTMLElement {
         });
       }
     });
+
+    this.shadowRoot.addEventListener("fd-demo-toggle", () => {
+      const dp = this.shadowRoot.querySelector("fd-data-provider");
+      const header = this.shadowRoot.querySelector("fd-header");
+      if (dp) {
+        dp.toggleDemo().then((enabled) => {
+          if (header) header.demoMode = enabled;
+        });
+      }
+    });
   }
 
   _onData(data) {
@@ -109,11 +119,12 @@ class FinanceDashboardPanel extends HTMLElement {
     content.className = "";
     content.innerHTML = "";
 
-    // Update header timestamp and rate limit state
+    // Update header timestamp, rate limit, and demo state
     const header = this.shadowRoot.querySelector("fd-header");
     if (header) {
       header.lastRefresh = data.lastRefresh;
       header.rateLimitedUntil = data.rateLimitedUntil;
+      if (data.demoMode !== undefined) header.demoMode = data.demoMode;
     }
 
     // Stats row

--- a/custom_components/finance_dashboard/manager.py
+++ b/custom_components/finance_dashboard/manager.py
@@ -63,6 +63,7 @@ class FinanceDashboardManager:
         self._transfer_overrides: dict[str, bool] = {}
         self._recurring_patterns: list[dict[str, Any]] = []
         self._previous_balances: dict[str, float] = {}
+        self._demo_mode: bool = False
 
     @property
     def rate_limited_until(self) -> datetime | None:
@@ -82,6 +83,37 @@ class FinanceDashboardManager:
             "API rate-limited — serving cached data until %s",
             tomorrow.isoformat(),
         )
+
+    @property
+    def demo_mode(self) -> bool:
+        """Return whether demo mode is active."""
+        return self._demo_mode
+
+    def set_demo_mode(self, enabled: bool) -> None:
+        """Toggle demo mode on or off.
+
+        When enabled, loads synthetic demo data into the manager's state.
+        When disabled, clears demo data and reverts to real cached data.
+        """
+        self._demo_mode = enabled
+        if enabled:
+            from .demo import generate_demo_data
+
+            data = generate_demo_data()
+            self._accounts = data["_demo_accounts"]
+            self._transactions = data["_demo_transactions"]
+            self._balances = data["_demo_balances"]
+            self._last_refresh = datetime.now()
+            self._recurring_patterns = data.get("recurring", [])
+            _LOGGER.info("Demo mode enabled — loaded synthetic data")
+        else:
+            # Clear demo data — real data reloads on next manual refresh
+            self._accounts = self._entry.data.get("accounts", [])
+            self._transactions = []
+            self._balances = {}
+            self._last_refresh = None
+            self._recurring_patterns = []
+            _LOGGER.info("Demo mode disabled — cleared synthetic data")
 
     async def async_initialize(self) -> None:
         """Initialize all sub-components."""
@@ -110,14 +142,17 @@ class FinanceDashboardManager:
 
     async def async_shutdown(self) -> None:
         """Clean shutdown — persist cache, clear sensitive data from memory."""
-        # Save current transactions before shutdown
-        await self._persist_transactions()
+        # Only persist real transactions — never overwrite cache with demo data
+        if not self._demo_mode:
+            await self._persist_transactions()
         self._banking_client = None
         self._balances.clear()
         _LOGGER.info("Finance Manager shut down")
 
     async def async_refresh_accounts(self) -> list[dict[str, Any]]:
         """Refresh account list from Enable Banking."""
+        if self._demo_mode:
+            return self._accounts
         client = await self._async_get_client()
         if not client:
             return []
@@ -161,6 +196,17 @@ class FinanceDashboardManager:
         data is served and no further API calls are attempted until
         the next calendar day (midnight local time).
         """
+        # Demo mode — regenerate fresh demo data without API calls
+        if self._demo_mode:
+            from .demo import generate_demo_data
+
+            data = generate_demo_data()
+            self._transactions = data["_demo_transactions"]
+            self._balances = data["_demo_balances"]
+            self._last_refresh = datetime.now()
+            self._recurring_patterns = data.get("recurring", [])
+            return self._transactions
+
         # Skip API calls if we're still rate-limited
         if self.rate_limited_until:
             _LOGGER.info(
@@ -303,6 +349,9 @@ class FinanceDashboardManager:
 
     async def async_get_balance(self) -> dict[str, Any]:
         """Get current balances for all accounts."""
+        if self._demo_mode:
+            return self._balances
+
         # Serve cached balances while rate-limited
         if self.rate_limited_until:
             _LOGGER.debug("Rate-limited — serving cached balances")
@@ -500,7 +549,7 @@ class FinanceDashboardManager:
 
     async def async_categorize_transactions(self) -> None:
         """Re-run auto-categorization on all cached transactions."""
-        if not self._categorizer:
+        if self._demo_mode or not self._categorizer:
             return
         for txn in self._transactions:
             txn["category"] = self._categorizer.categorize(txn)

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.8.1"
+  "version": "0.9.0"
 }

--- a/custom_components/finance_dashboard/services.yaml
+++ b/custom_components/finance_dashboard/services.yaml
@@ -1,6 +1,6 @@
 refresh_accounts:
   name: Refresh Accounts
-  description: Refresh the list of linked bank accounts from GoCardless.
+  description: Refresh the list of linked bank accounts from Enable Banking.
 
 refresh_transactions:
   name: Refresh Transactions
@@ -68,6 +68,10 @@ set_budget_limit:
           max: 100000
           step: 0.01
           mode: box
+
+toggle_demo:
+  name: Toggle Demo Mode
+  description: Toggle demo mode on/off. Generates realistic synthetic banking data for testing and demonstration.
 
 export_csv:
   name: Export CSV

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 
 
+
+## 0.9.0
+- Full demo mode with realistic German banking data (3 accounts, ~35 transactions, household split, recurring patterns)
+- Toggle via UI button (admin-only), service call, or options flow — persists across HA restarts
+- Manual-only API refresh — coordinator update_interval=None, data only updates on explicit user action
+- Initial coordinator refresh now works on config entry reloads (not just first HA start)
+- Shutdown no longer overwrites real transaction cache when demo mode is active
+- AttributeError in DemoToggleView coordinator lookup — null-safe access pattern
+- GoCardless reference replaced with Enable Banking in services.yaml
+- Removed dead COORDINATOR_UPDATE_INTERVAL constant and corrected all docstrings
+- Demo toggle button with DEMO badge, aria-pressed accessibility, mobile breakpoint
+- Rapid-click guard and loading state for demo API calls
+- DemoMode flag propagated in all data events for consistent UI state
+
 ## 0.8.1
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist
 - Restart notification no longer lost due to race condition in entry setup

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.8.1"
+version: "0.9.0"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DOMAIN,
+    SERVICE_TOGGLE_DEMO,
     STORAGE_KEY_AUDIT,
     STORAGE_VERSION,
 )
@@ -64,6 +65,10 @@ async def async_setup_entry(
     from .coordinator import FinanceDashboardCoordinator
 
     coordinator = FinanceDashboardCoordinator(hass, manager)
+
+    # Initialize demo mode from options
+    if entry.options.get("demo_mode", False):
+        manager.set_demo_mode(True)
 
     hass.data[DOMAIN][entry.entry_id] = manager
     hass.data[DOMAIN][f"{entry.entry_id}_coordinator"] = coordinator
@@ -119,18 +124,24 @@ async def async_setup_entry(
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Kick off the first coordinator refresh once HA is fully started.
-    # This populates entities with live data immediately without blocking startup.
-    if entry.data.get("configured"):
-        async def _initial_refresh(_event=None) -> None:
+    # Kick off the first coordinator refresh.
+    # Uses async_create_task so it works both on initial HA start AND
+    # on config entry reloads (homeassistant_started only fires once).
+    if entry.data.get("configured") or manager.demo_mode:
+        async def _initial_refresh() -> None:
             try:
                 await coordinator.async_refresh()
                 _LOGGER.info("Initial coordinator refresh completed")
             except Exception:
                 _LOGGER.exception("Initial coordinator refresh failed")
 
-
-        hass.bus.async_listen_once("homeassistant_started", _initial_refresh)
+        if hass.is_running:
+            hass.async_create_task(_initial_refresh())
+        else:
+            hass.bus.async_listen_once(
+                "homeassistant_started",
+                lambda _event: hass.async_create_task(_initial_refresh()),
+            )
 
     _LOGGER.info("Finance Dashboard v%s loaded", entry.version)
     return True
@@ -199,6 +210,11 @@ async def _async_register_services(
         )
         return {"path": path}
 
+    async def handle_toggle_demo(call) -> None:
+        enabled = not manager.demo_mode
+        manager.set_demo_mode(enabled)
+        await coordinator.async_refresh()
+
     hass.services.async_register(
         DOMAIN, SERVICE_REFRESH_ACCOUNTS, handle_refresh_accounts
     )
@@ -219,4 +235,7 @@ async def _async_register_services(
     )
     hass.services.async_register(
         DOMAIN, SERVICE_EXPORT_CSV, handle_export_csv
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_TOGGLE_DEMO, handle_toggle_demo
     )

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
@@ -42,6 +42,8 @@ async def async_register_api(hass: HomeAssistant) -> None:
     hass.http.register_view(FinanceDashboardSetupUsersView())
     hass.http.register_view(FinanceDashboardSetupUpdateAccountsView())
     hass.http.register_view(FinanceDashboardTransferChainsView())
+    hass.http.register_view(FinanceDashboardDemoToggleView())
+    hass.http.register_view(FinanceDashboardDemoDataView())
     _LOGGER.debug("Finance API endpoints registered")
 
 
@@ -989,6 +991,75 @@ class FinanceDashboardTransferChainsView(HomeAssistantView):
         return self.json(
             {"success": True, "chain_id": chain_id}
         )
+
+
+class FinanceDashboardDemoToggleView(HomeAssistantView):
+    """Toggle demo mode on/off (admin only)."""
+
+    url = f"/api/{DOMAIN}/demo/toggle"
+    name = f"api:{DOMAIN}:demo_toggle"
+    requires_auth = True
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Toggle demo mode and return new state."""
+        hass = request.app["hass"]
+
+        user = request.get("hass_user")
+        is_admin = user and user.is_admin if user else False
+        if not is_admin:
+            return self.json(
+                {"error": "Admin access required"},
+                status_code=403,
+            )
+
+        manager = _get_manager(hass)
+
+        if manager:
+            enabled = not manager.demo_mode
+            manager.set_demo_mode(enabled)
+
+            # Persist to entry.options so demo survives HA restarts
+            entry = hass.data.get(DOMAIN, {}).get("entry")
+            if entry:
+                new_options = {**entry.options, "demo_mode": enabled}
+                hass.config_entries.async_update_entry(
+                    entry, options=new_options
+                )
+
+            # Trigger coordinator refresh so entities update
+            domain_data = hass.data.get(DOMAIN, {})
+            coordinator = (
+                domain_data.get(f"{entry.entry_id}_coordinator")
+                if entry
+                else None
+            )
+            if coordinator:
+                await coordinator.async_refresh()
+            return self.json({"demo_mode": enabled})
+
+        # No manager — toggle in hass.data for API-only demo
+        current = hass.data.get(DOMAIN, {}).get("demo_mode", False)
+        hass.data.setdefault(DOMAIN, {})["demo_mode"] = not current
+        return self.json({"demo_mode": not current})
+
+
+class FinanceDashboardDemoDataView(HomeAssistantView):
+    """Return demo data — works with or without a config entry."""
+
+    url = f"/api/{DOMAIN}/demo/data"
+    name = f"api:{DOMAIN}:demo_data"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return a fresh demo dataset."""
+        from .demo import generate_demo_data
+
+        data = generate_demo_data()
+        # Strip internal keys
+        data.pop("_demo_accounts", None)
+        data.pop("_demo_transactions", None)
+        data.pop("_demo_balances", None)
+        return self.json(data)
 
 
 class FinanceDashboardSummaryView(HomeAssistantView):

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/config_flow.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/config_flow.py
@@ -253,6 +253,12 @@ class FinanceDashboardOptionsFlow(OptionsFlow):
                             "enable_dashboard_panel", True
                         ),
                     ): bool,
+                    vol.Optional(
+                        "demo_mode",
+                        default=self.config_entry.options.get(
+                            "demo_mode", False
+                        ),
+                    ): bool,
                 }
             ),
         )

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -123,3 +123,6 @@ REFUND_KEYWORDS = [
 
 # Household model
 DEFAULT_SPLIT_MODEL = "proportional"  # proportional, equal, custom
+
+# Demo mode
+SERVICE_TOGGLE_DEMO = "toggle_demo"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.8.1"
+VERSION = "0.9.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
@@ -2,7 +2,7 @@
 
 Centralises all Enable Banking API calls so that:
 - No entity ever calls the API directly
-- All updates happen on a fixed 10-minute schedule
+- Updates only happen on manual refresh (service call or UI button)
 - Rate limits are respected (transactions refreshed only when stale)
 - A single coordinator failure does not orphan individual entities
 """
@@ -19,15 +19,12 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-# Balance + summary: every 10 minutes
-COORDINATOR_UPDATE_INTERVAL = timedelta(minutes=10)
-
 # Only re-fetch raw transactions if cache is older than 6 hours
 TRANSACTION_REFRESH_STALENESS = timedelta(hours=6)
 
 
 class FinanceDashboardCoordinator(DataUpdateCoordinator):
-    """Fetch balances and monthly summary on a fixed schedule.
+    """Fetch balances and monthly summary on manual refresh only.
 
     Entities read from coordinator.data — they never call the banking
     API themselves.  Structure of coordinator.data:
@@ -38,18 +35,23 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
     """
 
     def __init__(self, hass: HomeAssistant, manager) -> None:
-        """Initialise coordinator with a reference to the manager."""
+        """Initialise coordinator with a reference to the manager.
+
+        update_interval is None — API calls only happen on manual refresh
+        (service call or UI button). Entities receive cached data from
+        the initial startup refresh and subsequent manual refreshes.
+        """
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=COORDINATOR_UPDATE_INTERVAL,
+            update_interval=None,
         )
         self._manager = manager
         self._first_update = True
 
     async def _async_update_data(self) -> dict:
-        """Called by HA every 10 minutes (and on demand via async_refresh)."""
+        """Called on demand via async_refresh() (manual refresh only)."""
         try:
             # Refresh raw transactions only when the cache is stale.
             # Balance calls happen on every cycle; transaction fetches are

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/demo.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/demo.py
@@ -1,0 +1,400 @@
+"""Demo data generator for Finance Dashboard.
+
+Generates realistic German banking data for demo/testing purposes.
+All data is synthetic — no real financial information.
+
+Each call to generate_demo_data() produces a complete, randomized dataset
+that matches the exact shape the frontend expects (unified data object).
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Demo bank accounts
+# ---------------------------------------------------------------------------
+
+DEMO_ACCOUNTS_CONFIG: list[dict[str, Any]] = [
+    {
+        "id": "demo-sparkasse-anna",
+        "iban": "DE89370400440532013000",
+        "name": "Girokonto",
+        "custom_name": "Anna Sparkasse",
+        "institution": "Sparkasse",
+        "institution_id": "SPARKASSE_DE",
+        "logo": "",
+        "currency": "EUR",
+        "type": "personal",
+        "person": "Anna",
+        "ha_users": [],
+    },
+    {
+        "id": "demo-dkb-max",
+        "iban": "DE27100110012621953188",
+        "name": "Girokonto",
+        "custom_name": "Max DKB",
+        "institution": "DKB",
+        "institution_id": "DKB_DE",
+        "logo": "",
+        "currency": "EUR",
+        "type": "personal",
+        "person": "Max",
+        "ha_users": [],
+    },
+    {
+        "id": "demo-ing-shared",
+        "iban": "DE60500105175418543281",
+        "name": "Gemeinschaftskonto",
+        "custom_name": "Haushaltskonto",
+        "institution": "ING",
+        "institution_id": "ING_DE",
+        "logo": "",
+        "currency": "EUR",
+        "type": "shared",
+        "person": "",
+        "ha_users": [],
+    },
+]
+
+# Base balances per account (randomized ±15%)
+_BASE_BALANCES = {
+    "demo-sparkasse-anna": 3250.00,
+    "demo-dkb-max": 2180.00,
+    "demo-ing-shared": 1520.00,
+}
+
+# ---------------------------------------------------------------------------
+# Transaction templates — amounts are jittered at generation time
+# ---------------------------------------------------------------------------
+
+_TRANSACTION_TEMPLATES: list[dict[str, Any]] = [
+    # --- Shared account (ING) ---
+    {"creditor": "Hausverwaltung GmbH", "desc": "Miete {month_name} {year}", "base": -1150.0, "cat": "housing", "day": 1, "acc": "demo-ing-shared"},
+    {"creditor": "Stadtwerke München", "desc": "Strom Abschlag", "base": -85.0, "cat": "utilities", "day": 3, "acc": "demo-ing-shared"},
+    {"creditor": "Telekom", "desc": "Festnetz + Internet", "base": -44.95, "cat": "utilities", "day": 5, "acc": "demo-ing-shared"},
+    {"creditor": "Allianz Versicherung", "desc": "Haftpflichtversicherung", "base": -12.50, "cat": "insurance", "day": 1, "acc": "demo-ing-shared"},
+    {"creditor": "GEZ", "desc": "Rundfunkbeitrag", "base": -18.36, "cat": "utilities", "day": 1, "acc": "demo-ing-shared"},
+    {"creditor": "REWE Markt", "desc": "REWE Großeinkauf", "base": -89.45, "cat": "food", "day": 4, "acc": "demo-ing-shared"},
+    {"creditor": "HelloFresh", "desc": "HelloFresh Kochbox KW14", "base": -49.99, "cat": "food", "day": 8, "acc": "demo-ing-shared"},
+
+    # --- Anna (Sparkasse) ---
+    {"creditor": "Arbeitgeber GmbH", "desc": "Gehalt {month_name}", "base": 3250.0, "cat": "income", "day": 25, "acc": "demo-sparkasse-anna"},
+    {"creditor": "REWE Markt", "desc": "REWE SAGT DANKE 4823", "base": -47.83, "cat": "food", "day": 2, "acc": "demo-sparkasse-anna"},
+    {"creditor": "EDEKA", "desc": "EDEKA Einkauf", "base": -32.15, "cat": "food", "day": 5, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Netflix", "desc": "Netflix Abo", "base": -13.99, "cat": "subscriptions", "day": 8, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Spotify", "desc": "Spotify Premium Family", "base": -17.99, "cat": "subscriptions", "day": 1, "acc": "demo-sparkasse-anna"},
+    {"creditor": "DB Vertrieb", "desc": "Deutschlandticket", "base": -49.00, "cat": "transport", "day": 1, "acc": "demo-sparkasse-anna"},
+    {"creditor": "ALDI", "desc": "ALDI SÜD Filiale 2847", "base": -28.47, "cat": "food", "day": 10, "acc": "demo-sparkasse-anna"},
+    {"creditor": "dm-drogerie", "desc": "dm Drogeriemarkt", "base": -15.99, "cat": "other", "day": 7, "acc": "demo-sparkasse-anna"},
+    {"creditor": "REWE Markt", "desc": "REWE SAGT DANKE 5121", "base": -52.30, "cat": "food", "day": 12, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Lieferando", "desc": "Lieferando Bestellung", "base": -24.90, "cat": "food", "day": 14, "acc": "demo-sparkasse-anna"},
+    {"creditor": "HUK-COBURG", "desc": "KFZ Versicherung", "base": -45.80, "cat": "insurance", "day": 1, "acc": "demo-sparkasse-anna"},
+    {"creditor": "LIDL", "desc": "LIDL SAGT DANKE", "base": -19.62, "cat": "food", "day": 16, "acc": "demo-sparkasse-anna"},
+    {"creditor": "Rossmann", "desc": "Rossmann Filiale", "base": -8.49, "cat": "other", "day": 18, "acc": "demo-sparkasse-anna"},
+
+    # --- Max (DKB) ---
+    {"creditor": "Tech AG", "desc": "Gehalt {month_name}", "base": 2850.0, "cat": "income", "day": 27, "acc": "demo-dkb-max"},
+    {"creditor": "REWE Markt", "desc": "REWE Einkauf", "base": -38.92, "cat": "food", "day": 3, "acc": "demo-dkb-max"},
+    {"creditor": "Lidl", "desc": "LIDL DIENSTL", "base": -22.47, "cat": "food", "day": 6, "acc": "demo-dkb-max"},
+    {"creditor": "Disney Plus", "desc": "Disney+ Abo", "base": -8.99, "cat": "subscriptions", "day": 15, "acc": "demo-dkb-max"},
+    {"creditor": "Xbox", "desc": "Xbox Game Pass Ultimate", "base": -14.99, "cat": "subscriptions", "day": 10, "acc": "demo-dkb-max"},
+    {"creditor": "Shell", "desc": "Shell Tankstelle München", "base": -65.40, "cat": "transport", "day": 8, "acc": "demo-dkb-max"},
+    {"creditor": "Amazon", "desc": "Amazon.de Bestellung", "base": -34.99, "cat": "other", "day": 11, "acc": "demo-dkb-max"},
+    {"creditor": "EDEKA", "desc": "EDEKA Center", "base": -41.23, "cat": "food", "day": 9, "acc": "demo-dkb-max"},
+    {"creditor": "McFIT", "desc": "McFIT Mitgliedschaft", "base": -29.90, "cat": "other", "day": 1, "acc": "demo-dkb-max"},
+    {"creditor": "ARAL", "desc": "ARAL Tankstelle", "base": -58.20, "cat": "transport", "day": 15, "acc": "demo-dkb-max"},
+    {"creditor": "HypoVereinsbank", "desc": "Autokredit Rate 48/60", "base": -285.00, "cat": "loans", "day": 5, "acc": "demo-dkb-max"},
+    {"creditor": "Barmer", "desc": "Zusatzversicherung Zahn", "base": -28.50, "cat": "insurance", "day": 1, "acc": "demo-dkb-max"},
+    {"creditor": "Google", "desc": "Google One 200 GB", "base": -2.99, "cat": "subscriptions", "day": 12, "acc": "demo-dkb-max"},
+    {"creditor": "REWE Markt", "desc": "REWE Abend-Einkauf", "base": -31.78, "cat": "food", "day": 17, "acc": "demo-dkb-max"},
+]
+
+# Recurring patterns for demo
+_RECURRING_TEMPLATES: list[dict[str, Any]] = [
+    {"creditor": "Hausverwaltung GmbH", "average_amount": -1150.0, "frequency": "monthly", "category": "housing", "occurrences": 12, "expected_day": 1},
+    {"creditor": "Stadtwerke München", "average_amount": -85.0, "frequency": "monthly", "category": "utilities", "occurrences": 12, "expected_day": 3},
+    {"creditor": "Telekom", "average_amount": -44.95, "frequency": "monthly", "category": "utilities", "occurrences": 12, "expected_day": 5},
+    {"creditor": "Netflix", "average_amount": -13.99, "frequency": "monthly", "category": "subscriptions", "occurrences": 8, "expected_day": 8},
+    {"creditor": "Spotify", "average_amount": -17.99, "frequency": "monthly", "category": "subscriptions", "occurrences": 11, "expected_day": 1},
+    {"creditor": "DB Vertrieb", "average_amount": -49.00, "frequency": "monthly", "category": "transport", "occurrences": 10, "expected_day": 1},
+    {"creditor": "HypoVereinsbank", "average_amount": -285.00, "frequency": "monthly", "category": "loans", "occurrences": 12, "expected_day": 5},
+    {"creditor": "HelloFresh", "average_amount": -49.99, "frequency": "monthly", "category": "food", "occurrences": 6, "expected_day": 8},
+]
+
+# Month names for German formatting
+_MONTH_NAMES = [
+    "Januar", "Februar", "März", "April", "Mai", "Juni",
+    "Juli", "August", "September", "Oktober", "November", "Dezember",
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_demo_data() -> dict[str, Any]:
+    """Generate a complete demo dataset matching the frontend unified data shape.
+
+    Returns a dict with keys: accounts, totalBalance, accountCount, summary,
+    budgets, splitModel, household, recurring, loading, error, lastRefresh,
+    rateLimitedUntil, _demo_accounts, _demo_transactions, _demo_balances.
+
+    The _demo_* keys are internal — used by the manager to populate entities.
+    """
+    rng = random.Random()
+    now = datetime.now()
+    month = now.month
+    year = now.year
+    month_name = _MONTH_NAMES[month - 1]
+
+    accounts = _build_accounts()
+    transactions = _build_transactions(rng, month, year, month_name)
+    balances = _build_balances(rng, accounts)
+
+    # Compute summary from transactions
+    category_totals: dict[str, float] = {}
+    total_income = 0.0
+    total_expenses = 0.0
+
+    for txn in transactions:
+        amount = float(txn["transactionAmount"]["amount"])
+        cat = txn.get("category", "other")
+        if amount > 0:
+            total_income += amount
+        else:
+            total_expenses += abs(amount)
+        category_totals[cat] = category_totals.get(cat, 0) + amount
+
+    fixed_cats = {"housing", "loans", "utilities", "insurance"}
+    fixed_total = sum(abs(category_totals.get(c, 0)) for c in fixed_cats)
+    variable_total = total_expenses - fixed_total
+
+    # Build household data
+    household = _build_household(rng, transactions, total_expenses)
+
+    # Build frontend account list
+    fe_accounts = []
+    total_balance = 0.0
+    for acc in accounts:
+        acc_id = acc["id"]
+        bal_data = balances.get(acc_id, {})
+        raw_bals = bal_data.get("balances", [])
+        bal_val = 0.0
+        if raw_bals:
+            bal_val = float(raw_bals[0].get("balanceAmount", {}).get("amount", 0))
+        iban = acc.get("iban", "")
+        fe_accounts.append({
+            "entityId": f"sensor.fd_demo_{acc_id.replace('-', '_')}",
+            "name": acc.get("custom_name") or acc.get("name", ""),
+            "institution": acc.get("institution", ""),
+            "balance": bal_val,
+            "ibanMasked": f"****{iban[-4:]}" if len(iban) >= 4 else "****",
+            "currency": acc.get("currency", "EUR"),
+            "person": acc.get("person", ""),
+        })
+        total_balance += bal_val
+
+    # Budget limits (demo defaults)
+    budgets = {
+        "housing": 1200.0,
+        "food": 600.0,
+        "transport": 200.0,
+        "subscriptions": 100.0,
+        "insurance": 150.0,
+        "utilities": 200.0,
+        "loans": 300.0,
+        "other": 200.0,
+    }
+
+    return {
+        # Frontend unified data shape
+        "accounts": fe_accounts,
+        "totalBalance": round(total_balance, 2),
+        "accountCount": len(fe_accounts),
+        "summary": {
+            "totalIncome": round(total_income, 2),
+            "totalExpenses": round(total_expenses, 2),
+            "balance": round(total_income - total_expenses, 2),
+            "categories": {k: round(v, 2) for k, v in category_totals.items()},
+            "transactionCount": len(transactions),
+            "fixedCosts": round(fixed_total, 2),
+            "variableCosts": round(variable_total, 2),
+            "month": month,
+            "year": year,
+        },
+        "budgets": budgets,
+        "splitModel": "proportional",
+        "household": household,
+        "recurring": _RECURRING_TEMPLATES[:8],
+        "loading": False,
+        "error": None,
+        "lastRefresh": now.isoformat(),
+        "rateLimitedUntil": None,
+        # Internal keys for manager/coordinator
+        "_demo_accounts": accounts,
+        "_demo_transactions": transactions,
+        "_demo_balances": balances,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal builders
+# ---------------------------------------------------------------------------
+
+
+def _build_accounts() -> list[dict[str, Any]]:
+    """Return a deep copy of demo accounts."""
+    return [dict(a) for a in DEMO_ACCOUNTS_CONFIG]
+
+
+def _build_transactions(
+    rng: random.Random,
+    month: int,
+    year: int,
+    month_name: str,
+) -> list[dict[str, Any]]:
+    """Generate demo transactions for the given month."""
+    today = datetime.now().day
+    transactions: list[dict[str, Any]] = []
+
+    # Build account lookup for tagging
+    acc_map = {a["id"]: a for a in DEMO_ACCOUNTS_CONFIG}
+
+    for i, tpl in enumerate(_TRANSACTION_TEMPLATES):
+        day = tpl["day"]
+        # Skip future dates within the month (including future salaries)
+        if day > today:
+            continue
+
+        # Jitter amount by ±8% (except fixed amounts like rent, salary)
+        base = tpl["base"]
+        if abs(base) > 100 and tpl["cat"] not in ("income", "housing", "loans"):
+            jitter = rng.uniform(-0.08, 0.08)
+            amount = round(base * (1 + jitter), 2)
+        elif abs(base) < 100:
+            jitter = rng.uniform(-0.12, 0.12)
+            amount = round(base * (1 + jitter), 2)
+        else:
+            amount = base
+
+        booking_date = f"{year}-{month:02d}-{day:02d}"
+        desc = tpl["desc"].format(month_name=month_name, year=year)
+        acc_id = tpl["acc"]
+        acc = acc_map.get(acc_id, {})
+
+        transactions.append({
+            "transactionId": f"demo-{i:04d}-{rng.randint(1000, 9999)}",
+            "bookingDate": booking_date,
+            "transactionAmount": {
+                "amount": str(amount),
+                "currency": "EUR",
+            },
+            "creditorName": tpl["creditor"],
+            "remittanceInformationUnstructured": desc,
+            "category": tpl["cat"],
+            "_account_id": acc_id,
+            "_account_name": acc.get("custom_name") or acc.get("name", ""),
+            "_account_type": acc.get("type", "personal"),
+            "_account_person": acc.get("person", ""),
+            "_account_ha_users": [],
+            "_status": "booked",
+        })
+
+    # Sort newest first
+    transactions.sort(key=lambda t: t["bookingDate"], reverse=True)
+    return transactions
+
+
+def _build_balances(
+    rng: random.Random,
+    accounts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Generate demo balance data per account."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    balances: dict[str, Any] = {}
+
+    for acc in accounts:
+        acc_id = acc["id"]
+        base = _BASE_BALANCES.get(acc_id, 1000.0)
+        amount = round(base * rng.uniform(0.85, 1.15), 2)
+        iban = acc.get("iban", "")
+
+        balances[acc_id] = {
+            "account_name": acc.get("custom_name") or acc.get("name", ""),
+            "iban": iban,
+            "iban_masked": f"****{iban[-4:]}" if len(iban) >= 4 else "****",
+            "institution": acc.get("institution", ""),
+            "logo": acc.get("logo", ""),
+            "balances": [
+                {
+                    "balanceType": "closingBooked",
+                    "balanceAmount": {
+                        "amount": str(amount),
+                        "currency": "EUR",
+                    },
+                    "referenceDate": today,
+                }
+            ],
+        }
+
+    return balances
+
+
+def _build_household(
+    rng: random.Random,
+    transactions: list[dict[str, Any]],
+    total_expenses: float,
+) -> dict[str, Any]:
+    """Build household split data from demo transactions."""
+    persons: dict[str, dict[str, float]] = {}
+    shared_costs = 0.0
+
+    for txn in transactions:
+        amount = float(txn["transactionAmount"]["amount"])
+        acc_type = txn.get("_account_type", "personal")
+        person = txn.get("_account_person", "")
+
+        if acc_type == "shared":
+            if amount < 0:
+                shared_costs += abs(amount)
+        elif person:
+            if person not in persons:
+                persons[person] = {"income": 0.0, "individual_costs": 0.0}
+            if amount > 0:
+                persons[person]["income"] += amount
+            else:
+                persons[person]["individual_costs"] += abs(amount)
+
+    if not persons:
+        return None
+
+    # Calculate proportional split
+    total_income = sum(p["income"] for p in persons.values())
+    members = []
+    for name, data in persons.items():
+        ratio = data["income"] / total_income if total_income > 0 else 0.5
+        share = shared_costs * ratio
+        spielgeld = data["income"] - data["individual_costs"] - share
+
+        members.append({
+            "person": name,
+            "gross_income": round(data["income"], 2),
+            "net_income": round(data["income"], 2),
+            "income_ratio": round(ratio * 100, 1),
+            "shared_costs_share": round(share, 2),
+            "individual_costs": round(data["individual_costs"], 2),
+            "spielgeld": round(spielgeld, 2),
+            "bonus_amount": 0.0,
+        })
+
+    return {
+        "members": members,
+        "split_model": "proportional",
+        "remainder_mode": "none",
+        "total_shared_costs": round(shared_costs, 2),
+    }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -24,22 +24,85 @@ class FdDataProvider extends HTMLElement {
     this._prevStateHash = "";
     this._initialRebuildDone = false;
     this._loading = false;
+    this._demoMode = false;
+    this._demoToggling = false;
   }
 
   get data() {
     return this._data;
   }
 
+  get demoMode() {
+    return this._demoMode;
+  }
+
   set hass(hass) {
     this._hass = hass;
+    // In demo mode, don't watch entity changes
+    if (this._demoMode) return;
     // Debounce: hass changes many times per second
     clearTimeout(this._debounceTimer);
     this._debounceTimer = setTimeout(() => this._onHassChanged(), DEBOUNCE_MS);
   }
 
+  /** Toggle demo mode — fetches demo data from API. Guarded against rapid clicks. */
+  async toggleDemo() {
+    if (!this._hass || this._demoToggling) return this._demoMode;
+    this._demoToggling = true;
+    try {
+      const result = await this._hass.callApi("POST", `${DOMAIN}/demo/toggle`);
+      this._demoMode = result.demo_mode;
+      if (this._demoMode) {
+        await this._loadDemoData();
+      } else {
+        // Revert to entity-based data
+        this._prevStateHash = "";
+        await this._rebuild();
+      }
+      return this._demoMode;
+    } catch (e) {
+      console.error("fd-data-provider: demo toggle failed:", e);
+      return this._demoMode;
+    } finally {
+      this._demoToggling = false;
+    }
+  }
+
+  /** Load demo data from the API endpoint. */
+  async _loadDemoData() {
+    if (!this._hass) return;
+    // Dispatch loading state
+    this.dispatchEvent(new CustomEvent("fd-data-updated", {
+      detail: { loading: true, demoMode: true },
+      bubbles: true,
+      composed: true,
+    }));
+    try {
+      const data = await this._hass.callApi("GET", `${DOMAIN}/demo/data`);
+      this._data = data;
+      this.dispatchEvent(new CustomEvent("fd-data-updated", {
+        detail: { ...data, demoMode: true },
+        bubbles: true,
+        composed: true,
+      }));
+    } catch (e) {
+      console.error("fd-data-provider: demo data fetch failed:", e);
+      this.dispatchEvent(new CustomEvent("fd-data-updated", {
+        detail: { error: "Demo-Daten konnten nicht geladen werden", demoMode: true },
+        bubbles: true,
+        composed: true,
+      }));
+    }
+  }
+
   /** Trigger a full data rebuild (manual refresh). */
   async refresh() {
     if (!this._hass) return;
+    if (this._demoMode) {
+      // In demo mode, just regenerate demo data
+      await this._loadDemoData();
+      return;
+    }
     // Ask HA to refresh transactions, which triggers coordinator update
     try {
       await this._hass.callService(DOMAIN, "refresh_transactions");
@@ -190,6 +253,7 @@ class FdDataProvider extends HTMLElement {
       }
 
       this._data = data;
+      data.demoMode = this._demoMode;
       this.dispatchEvent(new CustomEvent("fd-data-updated", {
         detail: data,
         bubbles: true,

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
@@ -15,6 +15,7 @@ class FdHeader extends HTMLElement {
     this._lastRefresh = null;
     this._refreshing = false;
     this._rateLimitedUntil = null;
+    this._demoMode = false;
   }
 
   set lastRefresh(v) {
@@ -30,6 +31,11 @@ class FdHeader extends HTMLElement {
   set rateLimitedUntil(v) {
     this._rateLimitedUntil = v;
     this._updateRefreshBtn();
+  }
+
+  set demoMode(v) {
+    this._demoMode = v;
+    this._updateDemoBtn();
   }
 
   _updateRefreshBtn() {
@@ -54,6 +60,22 @@ class FdHeader extends HTMLElement {
     this._render();
   }
 
+  _updateDemoBtn() {
+    const btn = this.shadowRoot.getElementById("demoBtn");
+    const badge = this.shadowRoot.getElementById("demoBadge");
+    if (!btn) return;
+    btn.setAttribute("aria-pressed", String(this._demoMode));
+    if (this._demoMode) {
+      btn.textContent = "Demo aus";
+      btn.classList.add("btn-demo-active");
+      if (badge) badge.style.display = "inline-block";
+    } else {
+      btn.textContent = "Demo";
+      btn.classList.remove("btn-demo-active");
+      if (badge) badge.style.display = "none";
+    }
+  }
+
   _render() {
     const monthNames = ["Jan", "Feb", "M\u00e4r", "Apr", "Mai", "Jun",
       "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"];
@@ -69,6 +91,7 @@ class FdHeader extends HTMLElement {
   --tx: var(--primary-text-color, #e0e0e0);
   --tx2: var(--secondary-text-color, #9898a8);
   --ac: var(--accent-color, #4ecca3);
+  --demo: #f39c12;
   display: block;
   margin-bottom: 24px;
 }
@@ -77,11 +100,27 @@ class FdHeader extends HTMLElement {
   justify-content: space-between;
   align-items: center;
 }
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 h1 {
   font-size: 24px;
   font-weight: 700;
   margin: 0;
   font-family: 'Segoe UI', system-ui, sans-serif;
+}
+.demo-badge {
+  display: none;
+  padding: 3px 10px;
+  border-radius: 6px;
+  background: var(--demo);
+  color: #0a0a0f;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
 }
 .right {
   display: flex;
@@ -110,11 +149,36 @@ h1 {
   border-color: var(--ac);
   font-weight: 600;
 }
+.btn-demo {
+  border-color: var(--demo);
+  color: var(--demo);
+}
+.btn-demo:hover {
+  background: rgba(243, 156, 18, 0.1);
+}
+.btn-demo-active {
+  background: var(--demo);
+  color: #0a0a0f;
+  font-weight: 600;
+}
+.btn-demo-active:hover {
+  background: #e67e22;
+}
+@media (max-width: 600px) {
+  .hdr { flex-wrap: wrap; gap: 10px; }
+  .right { width: 100%; justify-content: flex-end; }
+  h1 { font-size: 20px; }
+  .btn { padding: 6px 10px; font-size: 12px; }
+}
 </style>
 <div class="hdr">
-  <h1>Finance Dashboard</h1>
+  <div class="title-row">
+    <h1>Finance Dashboard</h1>
+    <span class="demo-badge" id="demoBadge">DEMO</span>
+  </div>
   <div class="right">
     <span class="ts" id="ts"></span>
+    <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
   </div>
@@ -128,7 +192,16 @@ h1 {
         }));
       });
 
+    this.shadowRoot.getElementById("demoBtn")
+      .addEventListener("click", () => {
+        this.dispatchEvent(new CustomEvent("fd-demo-toggle", {
+          bubbles: true,
+          composed: true,
+        }));
+      });
+
     this._updateTimestamp();
+    this._updateDemoBtn();
   }
 
   _updateTimestamp() {

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -93,6 +93,16 @@ class FinanceDashboardPanel extends HTMLElement {
         });
       }
     });
+
+    this.shadowRoot.addEventListener("fd-demo-toggle", () => {
+      const dp = this.shadowRoot.querySelector("fd-data-provider");
+      const header = this.shadowRoot.querySelector("fd-header");
+      if (dp) {
+        dp.toggleDemo().then((enabled) => {
+          if (header) header.demoMode = enabled;
+        });
+      }
+    });
   }
 
   _onData(data) {
@@ -109,11 +119,12 @@ class FinanceDashboardPanel extends HTMLElement {
     content.className = "";
     content.innerHTML = "";
 
-    // Update header timestamp and rate limit state
+    // Update header timestamp, rate limit, and demo state
     const header = this.shadowRoot.querySelector("fd-header");
     if (header) {
       header.lastRefresh = data.lastRefresh;
       header.rateLimitedUntil = data.rateLimitedUntil;
+      if (data.demoMode !== undefined) header.demoMode = data.demoMode;
     }
 
     // Stats row

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
@@ -63,6 +63,7 @@ class FinanceDashboardManager:
         self._transfer_overrides: dict[str, bool] = {}
         self._recurring_patterns: list[dict[str, Any]] = []
         self._previous_balances: dict[str, float] = {}
+        self._demo_mode: bool = False
 
     @property
     def rate_limited_until(self) -> datetime | None:
@@ -82,6 +83,37 @@ class FinanceDashboardManager:
             "API rate-limited — serving cached data until %s",
             tomorrow.isoformat(),
         )
+
+    @property
+    def demo_mode(self) -> bool:
+        """Return whether demo mode is active."""
+        return self._demo_mode
+
+    def set_demo_mode(self, enabled: bool) -> None:
+        """Toggle demo mode on or off.
+
+        When enabled, loads synthetic demo data into the manager's state.
+        When disabled, clears demo data and reverts to real cached data.
+        """
+        self._demo_mode = enabled
+        if enabled:
+            from .demo import generate_demo_data
+
+            data = generate_demo_data()
+            self._accounts = data["_demo_accounts"]
+            self._transactions = data["_demo_transactions"]
+            self._balances = data["_demo_balances"]
+            self._last_refresh = datetime.now()
+            self._recurring_patterns = data.get("recurring", [])
+            _LOGGER.info("Demo mode enabled — loaded synthetic data")
+        else:
+            # Clear demo data — real data reloads on next manual refresh
+            self._accounts = self._entry.data.get("accounts", [])
+            self._transactions = []
+            self._balances = {}
+            self._last_refresh = None
+            self._recurring_patterns = []
+            _LOGGER.info("Demo mode disabled — cleared synthetic data")
 
     async def async_initialize(self) -> None:
         """Initialize all sub-components."""
@@ -110,14 +142,17 @@ class FinanceDashboardManager:
 
     async def async_shutdown(self) -> None:
         """Clean shutdown — persist cache, clear sensitive data from memory."""
-        # Save current transactions before shutdown
-        await self._persist_transactions()
+        # Only persist real transactions — never overwrite cache with demo data
+        if not self._demo_mode:
+            await self._persist_transactions()
         self._banking_client = None
         self._balances.clear()
         _LOGGER.info("Finance Manager shut down")
 
     async def async_refresh_accounts(self) -> list[dict[str, Any]]:
         """Refresh account list from Enable Banking."""
+        if self._demo_mode:
+            return self._accounts
         client = await self._async_get_client()
         if not client:
             return []
@@ -161,6 +196,17 @@ class FinanceDashboardManager:
         data is served and no further API calls are attempted until
         the next calendar day (midnight local time).
         """
+        # Demo mode — regenerate fresh demo data without API calls
+        if self._demo_mode:
+            from .demo import generate_demo_data
+
+            data = generate_demo_data()
+            self._transactions = data["_demo_transactions"]
+            self._balances = data["_demo_balances"]
+            self._last_refresh = datetime.now()
+            self._recurring_patterns = data.get("recurring", [])
+            return self._transactions
+
         # Skip API calls if we're still rate-limited
         if self.rate_limited_until:
             _LOGGER.info(
@@ -303,6 +349,9 @@ class FinanceDashboardManager:
 
     async def async_get_balance(self) -> dict[str, Any]:
         """Get current balances for all accounts."""
+        if self._demo_mode:
+            return self._balances
+
         # Serve cached balances while rate-limited
         if self.rate_limited_until:
             _LOGGER.debug("Rate-limited — serving cached balances")
@@ -500,7 +549,7 @@ class FinanceDashboardManager:
 
     async def async_categorize_transactions(self) -> None:
         """Re-run auto-categorization on all cached transactions."""
-        if not self._categorizer:
+        if self._demo_mode or not self._categorizer:
             return
         for txn in self._transactions:
             txn["category"] = self._categorizer.categorize(txn)

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.8.1"
+  "version": "0.9.0"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/services.yaml
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/services.yaml
@@ -1,6 +1,6 @@
 refresh_accounts:
   name: Refresh Accounts
-  description: Refresh the list of linked bank accounts from GoCardless.
+  description: Refresh the list of linked bank accounts from Enable Banking.
 
 refresh_transactions:
   name: Refresh Transactions
@@ -68,6 +68,10 @@ set_budget_limit:
           max: 100000
           step: 0.01
           mode: box
+
+toggle_demo:
+  name: Toggle Demo Mode
+  description: Toggle demo mode on/off. Generates realistic synthetic banking data for testing and demonstration.
 
 export_csv:
   name: Export CSV


### PR DESCRIPTION
## Summary
- Full demo mode with realistic German banking data (3 accounts, 2 persons, ~35 transactions, household split, recurring patterns, budget limits)
- Manual-only API refresh — coordinator no longer auto-polls, respects low Enable Banking rate limits
- 11 bug fixes from 5-agent parallel review (QA, Backend, Frontend, Product, Research)

## Changes
* **demo.py** (new) — synthetic data generator: Sparkasse/DKB/ING accounts, Anna+Max household, categorized transactions
* **coordinator.py** — `update_interval=None`, manual-only refresh
* **api.py** — `/demo/toggle` (admin-only, persistent) + `/demo/data` endpoints
* **manager.py** — demo guards on all API methods, shutdown cache protection
* **fd-header.js** — demo toggle button with DEMO badge, aria-pressed, mobile breakpoint
* **fd-data-provider.js** — rapid-click guard, loading state, demoMode in all events

## Bug Fixes
* AttributeError in DemoToggleView coordinator lookup
* Initial refresh now works on config entry reloads (not just first HA start)
* Shutdown no longer overwrites real transaction cache in demo mode
* GoCardless → Enable Banking in services.yaml

## Test plan
- [x] py_compile all Python files
- [x] node --check all JS files
- [x] Version alignment (0.9.0)
- [x] Addon payload sync
- [ ] Toggle demo in HA UI → verify all dashboard sections populate
- [ ] Disable demo → verify real data flow resumes
- [ ] HA restart with demo enabled → verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)