### PR TITLE
fix(restart): notification not showing after add-on update

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,17 @@
 # Build Log
 
+## 0.9.1 — 2026-04-07
+Version: 0.9.1
+Branch: claude/optimistic-merkle
+PR: (pending)
+Changes:
+- fix(restart): add missing issue-level description to strings.json — Repairs card had no body text, rendering it invisible in some HA versions
+- fix(restart): add is_persistent=True to ir.async_create_issue — prevents HA from discarding the issue during internal operations
+- fix(restart): wrap synchronous file I/O (exists/read_text/unlink) in async_add_executor_job — HA 2024+ blocks or warns on sync I/O in event loop
+- fix(repairs): return None for unknown issue_ids instead of generic RepairsFlow()
+- chore: sync translations (en.json, de.json) with new issue description
+- chore: sync addon payload
+
 ## 0.9.0 — 2026-04-05
 Version: 0.9.0
 Branch: claude/practical-fermi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,20 @@ All notable changes to the Finance will be documented in this file.
 - Rapid-click guard and loading state for demo API calls
 - DemoMode flag propagated in all data events for consistent UI state
 
+## [0.9.1] — 2026-04-07
+
+### Added
+- Chore: sync addon payload
+
+### Changed
+- Chore: sync translations (en.json, de.json) with new issue description
+
+### Fixed
+- Add missing issue-level description to strings.json — Repairs card had no body text, rendering it invisible in some HA versions
+- Add is_persistent=True to ir.async_create_issue — prevents HA from discarding the issue during internal operations
+- Wrap synchronous file I/O (exists/read_text/unlink) in async_add_executor_job — HA 2024+ blocks or warns on sync I/O in event loop
+- Return None for unknown issue_ids instead of generic RepairsFlow()
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     marker_path = Path(
         hass.config.path(".storage/finance_dashboard_restart_needed.json")
     )
-    if not marker_path.exists():
+    if not await hass.async_add_executor_job(marker_path.exists):
         ir.async_delete_issue(hass, DOMAIN, "restart_required")
 
     # Initialize the manager (core business logic)
@@ -89,28 +89,38 @@ async def async_setup_entry(
 
     # Poll for add-on restart marker (every 60 seconds)
     async def _poll_restart_marker(_now) -> None:
-        marker_path = Path(
+        marker = Path(
             hass.config.path(".storage/finance_dashboard_restart_needed.json")
         )
-        if marker_path.exists():
+
+        def _read_and_delete_marker() -> dict | None:
+            """Read marker file and delete it (runs in executor)."""
+            if not marker.exists():
+                return None
             import json
 
             try:
-                data = json.loads(marker_path.read_text())
-                marker_path.unlink()
-                ir.async_create_issue(
-                    hass,
-                    DOMAIN,
-                    "restart_required",
-                    is_fixable=True,
-                    severity=ir.IssueSeverity.WARNING,
-                    translation_key="restart_required",
-                    translation_placeholders={
-                        "version": data.get("version", "unknown")
-                    },
-                )
+                data = json.loads(marker.read_text(encoding="utf-8"))
+                marker.unlink()
+                return data
             except Exception:
-                _LOGGER.exception("Failed to process restart marker")
+                _LOGGER.exception("Failed to read restart marker")
+                return None
+
+        data = await hass.async_add_executor_job(_read_and_delete_marker)
+        if data is not None:
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                "restart_required",
+                is_fixable=True,
+                is_persistent=True,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="restart_required",
+                translation_placeholders={
+                    "version": data.get("version", "unknown")
+                },
+            )
 
     entry.async_on_unload(
         async_track_time_interval(

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.9.0"
+VERSION = "0.9.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/custom_components/finance_dashboard/repairs.py
+++ b/custom_components/finance_dashboard/repairs.py
@@ -24,8 +24,8 @@ class RestartRequiredRepairFlow(RepairsFlow):
 
 async def async_create_fix_flow(
     hass: HomeAssistant, issue_id: str, data: dict | None
-) -> RepairsFlow:
+) -> RepairsFlow | None:
     """Create repair flows."""
     if issue_id == "restart_required":
         return RestartRequiredRepairFlow()
-    return RepairsFlow()
+    return None

--- a/custom_components/finance_dashboard/strings.json
+++ b/custom_components/finance_dashboard/strings.json
@@ -57,6 +57,7 @@
   "issues": {
     "restart_required": {
       "title": "Finance Update — Restart Required",
+      "description": "Finance has been updated to version {version}. A restart is required to apply the new version.",
       "fix_flow": {
         "step": {
           "init": {

--- a/custom_components/finance_dashboard/translations/de.json
+++ b/custom_components/finance_dashboard/translations/de.json
@@ -57,6 +57,7 @@
   "issues": {
     "restart_required": {
       "title": "Finance Update — Neustart erforderlich",
+      "description": "Finance wurde auf Version {version} aktualisiert. Ein Neustart ist erforderlich, um die neue Version zu aktivieren.",
       "fix_flow": {
         "step": {
           "init": {

--- a/custom_components/finance_dashboard/translations/en.json
+++ b/custom_components/finance_dashboard/translations/en.json
@@ -57,6 +57,7 @@
   "issues": {
     "restart_required": {
       "title": "Finance Update — Restart Required",
+      "description": "Finance has been updated to version {version}. A restart is required to apply the new version.",
       "fix_flow": {
         "step": {
           "init": {

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 
 
+
+## 0.9.1
+- Add missing issue-level description to strings.json — Repairs card had no body text, rendering it invisible in some HA versions
+- Add is_persistent=True to ir.async_create_issue — prevents HA from discarding the issue during internal operations
+- Wrap synchronous file I/O (exists/read_text/unlink) in async_add_executor_job — HA 2024+ blocks or warns on sync I/O in event loop
+- Return None for unknown issue_ids instead of generic RepairsFlow()
+- Chore: sync translations (en.json, de.json) with new issue description
+- Chore: sync addon payload
+
 ## 0.9.0
 - Full demo mode with realistic German banking data (3 accounts, ~35 transactions, household split, recurring patterns)
 - Toggle via UI button (admin-only), service call, or options flow — persists across HA restarts

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.9.0"
+version: "0.9.1"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     marker_path = Path(
         hass.config.path(".storage/finance_dashboard_restart_needed.json")
     )
-    if not marker_path.exists():
+    if not await hass.async_add_executor_job(marker_path.exists):
         ir.async_delete_issue(hass, DOMAIN, "restart_required")
 
     # Initialize the manager (core business logic)
@@ -89,28 +89,38 @@ async def async_setup_entry(
 
     # Poll for add-on restart marker (every 60 seconds)
     async def _poll_restart_marker(_now) -> None:
-        marker_path = Path(
+        marker = Path(
             hass.config.path(".storage/finance_dashboard_restart_needed.json")
         )
-        if marker_path.exists():
+
+        def _read_and_delete_marker() -> dict | None:
+            """Read marker file and delete it (runs in executor)."""
+            if not marker.exists():
+                return None
             import json
 
             try:
-                data = json.loads(marker_path.read_text())
-                marker_path.unlink()
-                ir.async_create_issue(
-                    hass,
-                    DOMAIN,
-                    "restart_required",
-                    is_fixable=True,
-                    severity=ir.IssueSeverity.WARNING,
-                    translation_key="restart_required",
-                    translation_placeholders={
-                        "version": data.get("version", "unknown")
-                    },
-                )
+                data = json.loads(marker.read_text(encoding="utf-8"))
+                marker.unlink()
+                return data
             except Exception:
-                _LOGGER.exception("Failed to process restart marker")
+                _LOGGER.exception("Failed to read restart marker")
+                return None
+
+        data = await hass.async_add_executor_job(_read_and_delete_marker)
+        if data is not None:
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                "restart_required",
+                is_fixable=True,
+                is_persistent=True,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="restart_required",
+                translation_placeholders={
+                    "version": data.get("version", "unknown")
+                },
+            )
 
     entry.async_on_unload(
         async_track_time_interval(

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.9.0"
+VERSION = "0.9.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "cryptography>=42.0.0"
   ],
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/repairs.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/repairs.py
@@ -24,8 +24,8 @@ class RestartRequiredRepairFlow(RepairsFlow):
 
 async def async_create_fix_flow(
     hass: HomeAssistant, issue_id: str, data: dict | None
-) -> RepairsFlow:
+) -> RepairsFlow | None:
     """Create repair flows."""
     if issue_id == "restart_required":
         return RestartRequiredRepairFlow()
-    return RepairsFlow()
+    return None

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/strings.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/strings.json
@@ -57,6 +57,7 @@
   "issues": {
     "restart_required": {
       "title": "Finance Update — Restart Required",
+      "description": "Finance has been updated to version {version}. A restart is required to apply the new version.",
       "fix_flow": {
         "step": {
           "init": {

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/de.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/de.json
@@ -57,6 +57,7 @@
   "issues": {
     "restart_required": {
       "title": "Finance Update — Neustart erforderlich",
+      "description": "Finance wurde auf Version {version} aktualisiert. Ein Neustart ist erforderlich, um die neue Version zu aktivieren.",
       "fix_flow": {
         "step": {
           "init": {

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/en.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/en.json
@@ -57,6 +57,7 @@
   "issues": {
     "restart_required": {
       "title": "Finance Update — Restart Required",
+      "description": "Finance has been updated to version {version}. A restart is required to apply the new version.",
       "fix_flow": {
         "step": {
           "init": {


### PR DESCRIPTION
## Summary
- Fix restart-required Repairs notification not appearing after companion add-on update
- Three bugs: missing issue description, non-persistent flag, sync I/O in async context
- Translations updated (EN + DE), payload synced

## Changes
- Add issue-level `description` to `strings.json` — Repairs card had no body text
- Add `is_persistent=True` to `ir.async_create_issue` — prevents HA from discarding issue
- Wrap file I/O in `async_add_executor_job` — HA 2024+ warns on sync I/O in event loop
- `repairs.py` returns `None` for unknown issue_ids instead of generic `RepairsFlow()`

## Test plan
- [x] Python syntax check passes
- [x] Payload sync verified
- [x] Version alignment verified (0.9.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)