### PR TITLE
feat(deps): add ha-customapps shared framework dependency

### DIFF
--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -15,7 +15,8 @@
   "documentation": "https://github.com/Jerry0022/homeassistant-finance",
   "iot_class": "cloud_polling",
   "requirements": [
-    "cryptography>=42.0.0"
+    "cryptography>=42.0.0",
+    "ha-customapps>=0.1.0"
   ],
   "version": "0.9.1"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -15,7 +15,8 @@
   "documentation": "https://github.com/Jerry0022/homeassistant-finance",
   "iot_class": "cloud_polling",
   "requirements": [
-    "cryptography>=42.0.0"
+    "cryptography>=42.0.0",
+    "ha-customapps>=0.1.0"
   ],
   "version": "0.9.1"
 }


### PR DESCRIPTION
## Summary
- Add `ha-customapps>=0.1.0` to manifest.json requirements
- HA auto-installs the shared framework package on integration load
- Package published at https://pypi.org/project/ha-customapps/0.1.0/
- Provides: RestartNotifier, PanelRegistrar, CredentialStore, VersionManager

## Test plan
- [x] Package builds and installs from PyPI
- [x] Payload synced
- [x] manifest.json valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)