### PR TITLE
refactor: use ha-customapps library for restart, repairs, and panel

### DIFF
--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -10,14 +10,11 @@ All credentials and tokens are stored in HA's encrypted .storage/ directory.
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from pathlib import Path
 
+from ha_customapps.restart import RestartNotifier
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DOMAIN,
@@ -47,12 +44,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: FinanceDashboardConfigEntry
 ) -> bool:
     """Set up Finance Dashboard from a config entry."""
-    # Only clean up stale restart issues if no pending marker exists
-    marker_path = Path(
-        hass.config.path(".storage/finance_dashboard_restart_needed.json")
-    )
-    if not await hass.async_add_executor_job(marker_path.exists):
-        ir.async_delete_issue(hass, DOMAIN, "restart_required")
+    # Restart notification via ha-customapps (marker polling + Repairs issue)
+    notifier = RestartNotifier(hass, DOMAIN)
+    await notifier.async_setup(entry)
 
     # Initialize the manager (core business logic)
     from .manager import FinanceDashboardManager
@@ -86,50 +80,6 @@ async def async_setup_entry(
     from .api import async_register_api
 
     await async_register_api(hass)
-
-    # Poll for add-on restart marker (every 60 seconds)
-    async def _poll_restart_marker(_now) -> None:
-        marker = Path(
-            hass.config.path(".storage/finance_dashboard_restart_needed.json")
-        )
-
-        def _read_and_delete_marker() -> dict | None:
-            """Read marker file and delete it (runs in executor)."""
-            if not marker.exists():
-                return None
-            import json
-
-            try:
-                data = json.loads(marker.read_text(encoding="utf-8"))
-                marker.unlink()
-                return data
-            except Exception:
-                _LOGGER.exception("Failed to read restart marker")
-                return None
-
-        data = await hass.async_add_executor_job(_read_and_delete_marker)
-        if data is not None:
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "restart_required",
-                is_fixable=True,
-                is_persistent=True,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="restart_required",
-                translation_placeholders={
-                    "version": data.get("version", "unknown")
-                },
-            )
-
-    entry.async_on_unload(
-        async_track_time_interval(
-            hass, _poll_restart_marker, timedelta(seconds=60)
-        )
-    )
-
-    # Fire first poll immediately so the user sees the notification within seconds
-    await _poll_restart_marker(None)
 
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/finance_dashboard/panel.py
+++ b/custom_components/finance_dashboard/panel.py
@@ -1,12 +1,11 @@
-"""Sidebar panel registration for Finance."""
+"""Sidebar panel registration for Finance — uses ha-customapps PanelRegistrar."""
 
 from __future__ import annotations
 
 import logging
 
-from homeassistant.components import panel_custom
+from ha_customapps.panel import PanelRegistrar
 from homeassistant.components.frontend import add_extra_js_url
-from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant
 
 from .const import (
@@ -40,50 +39,31 @@ LOVELACE_COMPONENTS = [
 
 
 async def async_register_panel(hass: HomeAssistant) -> None:
-    """Register the Finance sidebar panel.
-
-    Creates a sidebar entry that loads the finance dashboard
-    web component from the integration's static files.
-    """
+    """Register the Finance sidebar panel."""
     try:
-        # Register static file path for frontend assets
-        await hass.http.async_register_static_paths(
-            [
-                StaticPathConfig(
-                    STATIC_BASE,
-                    hass.config.path(
-                        "custom_components", DOMAIN, "frontend"
-                    ),
-                    True,  # Enable caching (matches YouTube Music Connector)
-                )
-            ]
-        )
-
-        # Register the sidebar panel via panel_custom API
-        await panel_custom.async_register_panel(
-            hass,
-            webcomponent_name=PANEL_COMPONENT_NAME,
-            frontend_url_path=PANEL_URL_PATH,
+        registrar = PanelRegistrar(
+            hass=hass,
+            domain=DOMAIN,
+            panel_component=PANEL_COMPONENT_NAME,
+            panel_title=PANEL_TITLE,
+            panel_icon=PANEL_ICON,
+            panel_url_path=PANEL_URL_PATH,
             module_url=PANEL_MODULE_PATH,
-            sidebar_title=PANEL_TITLE,
-            sidebar_icon=PANEL_ICON,
-            require_admin=False,
-            config={"domain": DOMAIN},
+            frontend_dir=hass.config.path(
+                "custom_components", DOMAIN, "frontend"
+            ),
+            lovelace_urls=LOVELACE_COMPONENTS,
         )
-
-        # Register Lovelace card JS for automations
-        for url in LOVELACE_COMPONENTS:
-            add_extra_js_url(hass, url)
-
-        _LOGGER.debug(
-            "Finance panel registered at /%s", PANEL_URL_PATH
-        )
+        await registrar.async_register()
+        _LOGGER.debug("Finance panel registered at /%s", PANEL_URL_PATH)
     except Exception:
         _LOGGER.exception("Failed to register Finance panel")
 
 
 async def async_unregister_panel(hass: HomeAssistant) -> None:
     """Unregister custom sidebar panel."""
+    from homeassistant.components import panel_custom
+
     try:
         panel_custom.async_unregister_panel(hass, PANEL_URL_PATH)
     except Exception:

--- a/custom_components/finance_dashboard/repairs.py
+++ b/custom_components/finance_dashboard/repairs.py
@@ -1,31 +1,3 @@
-"""Repair flows for Finance."""
+"""Repair flows for Finance — delegates to ha-customapps."""
 
-from __future__ import annotations
-
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
-from homeassistant.core import HomeAssistant
-
-
-class RestartRequiredRepairFlow(RepairsFlow):
-    """Handler for restart required repair."""
-
-    async def async_step_init(
-        self, user_input: dict | None = None
-    ) -> data_entry_flow.FlowResult:
-        """Handle the repair flow."""
-        if user_input is not None:
-            await self.hass.services.async_call(
-                "homeassistant", "restart"
-            )
-            return self.async_create_entry(data={}, title="")
-        return self.async_show_form(step_id="init")
-
-
-async def async_create_fix_flow(
-    hass: HomeAssistant, issue_id: str, data: dict | None
-) -> RepairsFlow | None:
-    """Create repair flows."""
-    if issue_id == "restart_required":
-        return RestartRequiredRepairFlow()
-    return None
+from ha_customapps.repairs import async_create_fix_flow  # noqa: F401

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -10,14 +10,11 @@ All credentials and tokens are stored in HA's encrypted .storage/ directory.
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from pathlib import Path
 
+from ha_customapps.restart import RestartNotifier
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DOMAIN,
@@ -47,12 +44,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: FinanceDashboardConfigEntry
 ) -> bool:
     """Set up Finance Dashboard from a config entry."""
-    # Only clean up stale restart issues if no pending marker exists
-    marker_path = Path(
-        hass.config.path(".storage/finance_dashboard_restart_needed.json")
-    )
-    if not await hass.async_add_executor_job(marker_path.exists):
-        ir.async_delete_issue(hass, DOMAIN, "restart_required")
+    # Restart notification via ha-customapps (marker polling + Repairs issue)
+    notifier = RestartNotifier(hass, DOMAIN)
+    await notifier.async_setup(entry)
 
     # Initialize the manager (core business logic)
     from .manager import FinanceDashboardManager
@@ -86,50 +80,6 @@ async def async_setup_entry(
     from .api import async_register_api
 
     await async_register_api(hass)
-
-    # Poll for add-on restart marker (every 60 seconds)
-    async def _poll_restart_marker(_now) -> None:
-        marker = Path(
-            hass.config.path(".storage/finance_dashboard_restart_needed.json")
-        )
-
-        def _read_and_delete_marker() -> dict | None:
-            """Read marker file and delete it (runs in executor)."""
-            if not marker.exists():
-                return None
-            import json
-
-            try:
-                data = json.loads(marker.read_text(encoding="utf-8"))
-                marker.unlink()
-                return data
-            except Exception:
-                _LOGGER.exception("Failed to read restart marker")
-                return None
-
-        data = await hass.async_add_executor_job(_read_and_delete_marker)
-        if data is not None:
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "restart_required",
-                is_fixable=True,
-                is_persistent=True,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="restart_required",
-                translation_placeholders={
-                    "version": data.get("version", "unknown")
-                },
-            )
-
-    entry.async_on_unload(
-        async_track_time_interval(
-            hass, _poll_restart_marker, timedelta(seconds=60)
-        )
-    )
-
-    # Fire first poll immediately so the user sees the notification within seconds
-    await _poll_restart_marker(None)
 
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
@@ -1,12 +1,11 @@
-"""Sidebar panel registration for Finance."""
+"""Sidebar panel registration for Finance — uses ha-customapps PanelRegistrar."""
 
 from __future__ import annotations
 
 import logging
 
-from homeassistant.components import panel_custom
+from ha_customapps.panel import PanelRegistrar
 from homeassistant.components.frontend import add_extra_js_url
-from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant
 
 from .const import (
@@ -40,50 +39,31 @@ LOVELACE_COMPONENTS = [
 
 
 async def async_register_panel(hass: HomeAssistant) -> None:
-    """Register the Finance sidebar panel.
-
-    Creates a sidebar entry that loads the finance dashboard
-    web component from the integration's static files.
-    """
+    """Register the Finance sidebar panel."""
     try:
-        # Register static file path for frontend assets
-        await hass.http.async_register_static_paths(
-            [
-                StaticPathConfig(
-                    STATIC_BASE,
-                    hass.config.path(
-                        "custom_components", DOMAIN, "frontend"
-                    ),
-                    True,  # Enable caching (matches YouTube Music Connector)
-                )
-            ]
-        )
-
-        # Register the sidebar panel via panel_custom API
-        await panel_custom.async_register_panel(
-            hass,
-            webcomponent_name=PANEL_COMPONENT_NAME,
-            frontend_url_path=PANEL_URL_PATH,
+        registrar = PanelRegistrar(
+            hass=hass,
+            domain=DOMAIN,
+            panel_component=PANEL_COMPONENT_NAME,
+            panel_title=PANEL_TITLE,
+            panel_icon=PANEL_ICON,
+            panel_url_path=PANEL_URL_PATH,
             module_url=PANEL_MODULE_PATH,
-            sidebar_title=PANEL_TITLE,
-            sidebar_icon=PANEL_ICON,
-            require_admin=False,
-            config={"domain": DOMAIN},
+            frontend_dir=hass.config.path(
+                "custom_components", DOMAIN, "frontend"
+            ),
+            lovelace_urls=LOVELACE_COMPONENTS,
         )
-
-        # Register Lovelace card JS for automations
-        for url in LOVELACE_COMPONENTS:
-            add_extra_js_url(hass, url)
-
-        _LOGGER.debug(
-            "Finance panel registered at /%s", PANEL_URL_PATH
-        )
+        await registrar.async_register()
+        _LOGGER.debug("Finance panel registered at /%s", PANEL_URL_PATH)
     except Exception:
         _LOGGER.exception("Failed to register Finance panel")
 
 
 async def async_unregister_panel(hass: HomeAssistant) -> None:
     """Unregister custom sidebar panel."""
+    from homeassistant.components import panel_custom
+
     try:
         panel_custom.async_unregister_panel(hass, PANEL_URL_PATH)
     except Exception:

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/repairs.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/repairs.py
@@ -1,31 +1,3 @@
-"""Repair flows for Finance."""
+"""Repair flows for Finance — delegates to ha-customapps."""
 
-from __future__ import annotations
-
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
-from homeassistant.core import HomeAssistant
-
-
-class RestartRequiredRepairFlow(RepairsFlow):
-    """Handler for restart required repair."""
-
-    async def async_step_init(
-        self, user_input: dict | None = None
-    ) -> data_entry_flow.FlowResult:
-        """Handle the repair flow."""
-        if user_input is not None:
-            await self.hass.services.async_call(
-                "homeassistant", "restart"
-            )
-            return self.async_create_entry(data={}, title="")
-        return self.async_show_form(step_id="init")
-
-
-async def async_create_fix_flow(
-    hass: HomeAssistant, issue_id: str, data: dict | None
-) -> RepairsFlow | None:
-    """Create repair flows."""
-    if issue_id == "restart_required":
-        return RestartRequiredRepairFlow()
-    return None
+from ha_customapps.repairs import async_create_fix_flow  # noqa: F401


### PR DESCRIPTION
## Summary
- Replace inline restart marker polling with `RestartNotifier` from ha-customapps
- Replace custom repairs.py with one-liner re-export from ha-customapps
- Replace manual panel registration with `PanelRegistrar` from ha-customapps
- **-244 lines, +48 lines** — same behavior, shared library

## Changes
| File | Before | After |
|---|---|---|
| `__init__.py` | 40-line inline marker poll + issue creation | `RestartNotifier(hass, DOMAIN).async_setup(entry)` |
| `repairs.py` | 32-line custom RepairsFlow class | `from ha_customapps.repairs import async_create_fix_flow` |
| `panel.py` | Manual static paths + panel_custom + lovelace | `PanelRegistrar(...).async_register()` |

## Test plan
- [x] Python syntax check passes
- [x] Payload synced (3 files)
- [x] Version alignment verified (0.9.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)