### PR TITLE
refactor: manual-only API calls + onboarding state

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,18 @@
 # Build Log
 
+## 0.9.2 — 2026-04-11
+Version: 0.9.2
+Branch: claude/sharp-shockley
+PR: (pending)
+Changes:
+- refactor(core): remove automatic banking API calls on HA startup — coordinator now loads from cache only, no external calls until user clicks "Aktualisieren"
+- refactor(core): remove _first_update force-refresh flag from coordinator — staleness check is sufficient
+- refactor(frontend): remove automatic API fallback in _rebuild() — /summary endpoint only called on explicit user refresh, not on every entity change
+- feat(frontend): add onboarding welcome screen with "Demo starten" CTA when no bank accounts connected
+- feat(frontend): show "Noch keine Daten" timestamp fallback when no refresh has occurred
+- feat(frontend): make Demo button more prominent with visible background fill
+- fix(frontend): handle loading state in _onData to prevent clearing content during demo toggle
+
 ## 0.9.1 — 2026-04-07
 Version: 0.9.1
 Branch: claude/optimistic-merkle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,21 @@ All notable changes to the Finance will be documented in this file.
 - Wrap synchronous file I/O (exists/read_text/unlink) in async_add_executor_job — HA 2024+ blocks or warns on sync I/O in event loop
 - Return None for unknown issue_ids instead of generic RepairsFlow()
 
+## [0.9.2] — 2026-04-11
+
+### Added
+- Add onboarding welcome screen with "Demo starten" CTA when no bank accounts connected
+- Show "Noch keine Daten" timestamp fallback when no refresh has occurred
+- Make Demo button more prominent with visible background fill
+
+### Changed
+- Remove automatic banking API calls on HA startup — coordinator now loads from cache only, no external calls until user clicks "Aktualisieren"
+- Remove _first_update force-refresh flag from coordinator — staleness check is sufficient
+- Remove automatic API fallback in _rebuild() — /summary endpoint only called on explicit user refresh, not on every entity change
+
+### Fixed
+- Handle loading state in _onData to prevent clearing content during demo toggle
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -84,23 +84,24 @@ async def async_setup_entry(
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Kick off the first coordinator refresh.
-    # Uses async_create_task so it works both on initial HA start AND
-    # on config entry reloads (homeassistant_started only fires once).
+    # Load cached data into coordinator — NO external API calls.
+    # Entities are populated immediately from the transaction cache
+    # that was loaded in manager.async_initialize(). The user must
+    # click "Aktualisieren" to trigger real banking API calls.
     if entry.data.get("configured") or manager.demo_mode:
-        async def _initial_refresh() -> None:
+        async def _initial_load() -> None:
             try:
-                await coordinator.async_refresh()
-                _LOGGER.info("Initial coordinator refresh completed")
+                await coordinator.async_load_cached()
+                _LOGGER.info("Initial cached data loaded (no API calls)")
             except Exception:
-                _LOGGER.exception("Initial coordinator refresh failed")
+                _LOGGER.exception("Initial cached data load failed")
 
         if hass.is_running:
-            hass.async_create_task(_initial_refresh())
+            hass.async_create_task(_initial_load())
         else:
             hass.bus.async_listen_once(
                 "homeassistant_started",
-                lambda _event: hass.async_create_task(_initial_refresh()),
+                lambda _event: hass.async_create_task(_initial_load()),
             )
 
     _LOGGER.info("Finance Dashboard v%s loaded", entry.version)

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/coordinator.py
+++ b/custom_components/finance_dashboard/coordinator.py
@@ -48,20 +48,36 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
             update_interval=None,
         )
         self._manager = manager
-        self._first_update = True
+
+    async def async_load_cached(self) -> None:
+        """Populate coordinator data from cache only — zero API calls.
+
+        Used on startup to feed entities with cached transactions/balances
+        without hitting the banking API. The user must click "Aktualisieren"
+        to trigger real API calls.
+        """
+        try:
+            summary = await self._manager.async_get_monthly_summary()
+            rate_limited = self._manager.rate_limited_until
+            self.async_set_updated_data({
+                "balances": self._manager._balances,
+                "summary": summary,
+                "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
+            })
+            _LOGGER.debug("Loaded cached data into coordinator (no API calls)")
+        except Exception:
+            _LOGGER.exception("Failed to load cached data into coordinator")
 
     async def _async_update_data(self) -> dict:
-        """Called on demand via async_refresh() (manual refresh only)."""
+        """Called on demand via async_refresh() (manual refresh only).
+
+        This method is ONLY reached when the user explicitly triggers
+        a refresh (UI button or service call). It never runs automatically.
+        """
         try:
             # Refresh raw transactions only when the cache is stale.
-            # Balance calls happen on every cycle; transaction fetches are
-            # kept infrequent to stay within API rate limits.
-            # On first coordinator cycle, always refresh to ensure fresh data
-            # even if cached _last_refresh appears recent from a prior session.
             last = self._manager._last_refresh
-            force_first = self._first_update
-            self._first_update = False
-            if force_first or last is None or (datetime.now() - last) > TRANSACTION_REFRESH_STALENESS:
+            if last is None or (datetime.now() - last) > TRANSACTION_REFRESH_STALENESS:
                 _LOGGER.debug("Transaction cache stale — refreshing from API")
                 await self._manager.async_refresh_transactions()
 

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -109,9 +109,9 @@ class FdDataProvider extends HTMLElement {
     } catch (e) {
       console.warn("fd-data-provider: refresh_transactions failed:", e);
     }
-    // Force immediate rebuild
+    // Force immediate rebuild — allow API fallback for household/recurring
     this._prevStateHash = "";
-    await this._rebuild();
+    await this._rebuild(true);
   }
 
   /** Check if relevant entity states changed and rebuild if needed. */
@@ -139,8 +139,13 @@ class FdDataProvider extends HTMLElement {
     return parts.join(";");
   }
 
-  /** Rebuild the unified data object from entities + API. */
-  async _rebuild() {
+  /**
+   * Rebuild the unified data object from entities.
+   * @param {boolean} allowApiFallback — if true, fetch household/recurring
+   *   from the summary API when not available in entity attributes.
+   *   Only true during explicit user-triggered refresh.
+   */
+  async _rebuild(allowApiFallback = false) {
     if (!this._hass || this._loading) return;
     this._loading = true;
 
@@ -219,8 +224,9 @@ class FdDataProvider extends HTMLElement {
         if (sa.recurring) data.recurring = sa.recurring;
       }
 
-      // 4. If household/recurring not in entity attrs, fetch via API
-      if (!data.household || !data.recurring || data.recurring.length === 0) {
+      // 4. Fetch household/recurring from API ONLY on explicit user refresh
+      if (allowApiFallback &&
+          (!data.household || !data.recurring || data.recurring.length === 0)) {
         try {
           const summary = await this._hass.callApi("GET", `${DOMAIN}/summary`);
           if (summary) {

--- a/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/custom_components/finance_dashboard/frontend/fd-header.js
@@ -151,10 +151,12 @@ h1 {
 }
 .btn-demo {
   border-color: var(--demo);
+  background: rgba(243, 156, 18, 0.15);
   color: var(--demo);
+  font-weight: 600;
 }
 .btn-demo:hover {
-  background: rgba(243, 156, 18, 0.1);
+  background: rgba(243, 156, 18, 0.25);
 }
 .btn-demo-active {
   background: var(--demo);
@@ -177,7 +179,7 @@ h1 {
     <span class="demo-badge" id="demoBadge">DEMO</span>
   </div>
   <div class="right">
-    <span class="ts" id="ts"></span>
+    <span class="ts" id="ts">Noch keine Daten</span>
     <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -109,16 +109,6 @@ class FinanceDashboardPanel extends HTMLElement {
     const content = this.shadowRoot.getElementById("content");
     if (!content) return;
 
-    if (data.error) {
-      content.className = "error";
-      content.innerHTML = `<div>Verbinde dein Bankkonto unter Einstellungen \u2192 Integrationen \u2192 Finance.</div>`;
-      return;
-    }
-
-    // Clear loading state and build component tree
-    content.className = "";
-    content.innerHTML = "";
-
     // Update header timestamp, rate limit, and demo state
     const header = this.shadowRoot.querySelector("fd-header");
     if (header) {
@@ -126,6 +116,50 @@ class FinanceDashboardPanel extends HTMLElement {
       header.rateLimitedUntil = data.rateLimitedUntil;
       if (data.demoMode !== undefined) header.demoMode = data.demoMode;
     }
+
+    // Loading state (e.g. during demo toggle)
+    if (data.loading) return;
+
+    if (data.error) {
+      content.className = "error";
+      content.innerHTML = `<div>Verbinde dein Bankkonto unter Einstellungen \u2192 Integrationen \u2192 Finance.</div>`;
+      return;
+    }
+
+    // Onboarding: no accounts and no demo → show welcome with demo CTA
+    if (data.accountCount === 0 && !data.demoMode) {
+      content.className = "";
+      content.innerHTML = `
+<div style="text-align:center;padding:60px 20px;max-width:480px;margin:0 auto;">
+  <div style="font-size:48px;margin-bottom:16px;">&#x1F3E6;</div>
+  <h2 style="margin:0 0 8px;font-size:20px;font-weight:600;">Willkommen beim Finance Dashboard</h2>
+  <p style="color:var(--tx2);margin:0 0 24px;line-height:1.5;">
+    Noch keine Bankkonten verbunden. Starte den Demo-Modus um das Dashboard mit Beispieldaten zu erkunden, oder verbinde dein Bankkonto unter Einstellungen.
+  </p>
+  <button id="onboardingDemoBtn" style="
+    padding:12px 28px;border-radius:12px;border:2px solid #f39c12;
+    background:#f39c12;color:#0a0a0f;font-size:15px;font-weight:700;
+    cursor:pointer;font-family:inherit;margin-bottom:12px;
+  ">Demo starten</button>
+  <div style="margin-top:16px;">
+    <a href="/config/integrations" style="color:var(--tx2);font-size:13px;text-decoration:underline;">
+      Bankkonto verbinden \u2192
+    </a>
+  </div>
+</div>`;
+      content.querySelector("#onboardingDemoBtn")
+        .addEventListener("click", () => {
+          this.shadowRoot.dispatchEvent(new CustomEvent("fd-demo-toggle", {
+            bubbles: true,
+            composed: true,
+          }));
+        });
+      return;
+    }
+
+    // Clear loading state and build component tree
+    content.className = "";
+    content.innerHTML = "";
 
     // Stats row
     const statsRow = document.createElement("fd-stats-row");

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "cloud_polling",
   "requirements": [
     "cryptography>=42.0.0",
-    "ha-customapps>=0.1.0"
+    "ha-customapps>=0.3.0"
   ],
   "version": "0.9.1"
 }

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 
 
+
+## 0.9.2
+- Remove automatic banking API calls on HA startup — coordinator now loads from cache only, no external calls until user clicks "Aktualisieren"
+- Remove _first_update force-refresh flag from coordinator — staleness check is sufficient
+- Remove automatic API fallback in _rebuild() — /summary endpoint only called on explicit user refresh, not on every entity change
+- Add onboarding welcome screen with "Demo starten" CTA when no bank accounts connected
+- Show "Noch keine Daten" timestamp fallback when no refresh has occurred
+- Make Demo button more prominent with visible background fill
+- Handle loading state in _onData to prevent clearing content during demo toggle
+
 ## 0.9.1
 - Add missing issue-level description to strings.json — Repairs card had no body text, rendering it invisible in some HA versions
 - Add is_persistent=True to ir.async_create_issue — prevents HA from discarding the issue during internal operations

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.9.1"
+version: "0.9.2"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -84,23 +84,24 @@ async def async_setup_entry(
     # Forward platform setup — sensors/numbers/selects will register themselves
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Kick off the first coordinator refresh.
-    # Uses async_create_task so it works both on initial HA start AND
-    # on config entry reloads (homeassistant_started only fires once).
+    # Load cached data into coordinator — NO external API calls.
+    # Entities are populated immediately from the transaction cache
+    # that was loaded in manager.async_initialize(). The user must
+    # click "Aktualisieren" to trigger real banking API calls.
     if entry.data.get("configured") or manager.demo_mode:
-        async def _initial_refresh() -> None:
+        async def _initial_load() -> None:
             try:
-                await coordinator.async_refresh()
-                _LOGGER.info("Initial coordinator refresh completed")
+                await coordinator.async_load_cached()
+                _LOGGER.info("Initial cached data loaded (no API calls)")
             except Exception:
-                _LOGGER.exception("Initial coordinator refresh failed")
+                _LOGGER.exception("Initial cached data load failed")
 
         if hass.is_running:
-            hass.async_create_task(_initial_refresh())
+            hass.async_create_task(_initial_load())
         else:
             hass.bus.async_listen_once(
                 "homeassistant_started",
-                lambda _event: hass.async_create_task(_initial_refresh()),
+                lambda _event: hass.async_create_task(_initial_load()),
             )
 
     _LOGGER.info("Finance Dashboard v%s loaded", entry.version)

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
@@ -48,20 +48,36 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
             update_interval=None,
         )
         self._manager = manager
-        self._first_update = True
+
+    async def async_load_cached(self) -> None:
+        """Populate coordinator data from cache only — zero API calls.
+
+        Used on startup to feed entities with cached transactions/balances
+        without hitting the banking API. The user must click "Aktualisieren"
+        to trigger real API calls.
+        """
+        try:
+            summary = await self._manager.async_get_monthly_summary()
+            rate_limited = self._manager.rate_limited_until
+            self.async_set_updated_data({
+                "balances": self._manager._balances,
+                "summary": summary,
+                "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
+            })
+            _LOGGER.debug("Loaded cached data into coordinator (no API calls)")
+        except Exception:
+            _LOGGER.exception("Failed to load cached data into coordinator")
 
     async def _async_update_data(self) -> dict:
-        """Called on demand via async_refresh() (manual refresh only)."""
+        """Called on demand via async_refresh() (manual refresh only).
+
+        This method is ONLY reached when the user explicitly triggers
+        a refresh (UI button or service call). It never runs automatically.
+        """
         try:
             # Refresh raw transactions only when the cache is stale.
-            # Balance calls happen on every cycle; transaction fetches are
-            # kept infrequent to stay within API rate limits.
-            # On first coordinator cycle, always refresh to ensure fresh data
-            # even if cached _last_refresh appears recent from a prior session.
             last = self._manager._last_refresh
-            force_first = self._first_update
-            self._first_update = False
-            if force_first or last is None or (datetime.now() - last) > TRANSACTION_REFRESH_STALENESS:
+            if last is None or (datetime.now() - last) > TRANSACTION_REFRESH_STALENESS:
                 _LOGGER.debug("Transaction cache stale — refreshing from API")
                 await self._manager.async_refresh_transactions()
 

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -109,9 +109,9 @@ class FdDataProvider extends HTMLElement {
     } catch (e) {
       console.warn("fd-data-provider: refresh_transactions failed:", e);
     }
-    // Force immediate rebuild
+    // Force immediate rebuild — allow API fallback for household/recurring
     this._prevStateHash = "";
-    await this._rebuild();
+    await this._rebuild(true);
   }
 
   /** Check if relevant entity states changed and rebuild if needed. */
@@ -139,8 +139,13 @@ class FdDataProvider extends HTMLElement {
     return parts.join(";");
   }
 
-  /** Rebuild the unified data object from entities + API. */
-  async _rebuild() {
+  /**
+   * Rebuild the unified data object from entities.
+   * @param {boolean} allowApiFallback — if true, fetch household/recurring
+   *   from the summary API when not available in entity attributes.
+   *   Only true during explicit user-triggered refresh.
+   */
+  async _rebuild(allowApiFallback = false) {
     if (!this._hass || this._loading) return;
     this._loading = true;
 
@@ -219,8 +224,9 @@ class FdDataProvider extends HTMLElement {
         if (sa.recurring) data.recurring = sa.recurring;
       }
 
-      // 4. If household/recurring not in entity attrs, fetch via API
-      if (!data.household || !data.recurring || data.recurring.length === 0) {
+      // 4. Fetch household/recurring from API ONLY on explicit user refresh
+      if (allowApiFallback &&
+          (!data.household || !data.recurring || data.recurring.length === 0)) {
         try {
           const summary = await this._hass.callApi("GET", `${DOMAIN}/summary`);
           if (summary) {

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
@@ -151,10 +151,12 @@ h1 {
 }
 .btn-demo {
   border-color: var(--demo);
+  background: rgba(243, 156, 18, 0.15);
   color: var(--demo);
+  font-weight: 600;
 }
 .btn-demo:hover {
-  background: rgba(243, 156, 18, 0.1);
+  background: rgba(243, 156, 18, 0.25);
 }
 .btn-demo-active {
   background: var(--demo);
@@ -177,7 +179,7 @@ h1 {
     <span class="demo-badge" id="demoBadge">DEMO</span>
   </div>
   <div class="right">
-    <span class="ts" id="ts"></span>
+    <span class="ts" id="ts">Noch keine Daten</span>
     <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -109,16 +109,6 @@ class FinanceDashboardPanel extends HTMLElement {
     const content = this.shadowRoot.getElementById("content");
     if (!content) return;
 
-    if (data.error) {
-      content.className = "error";
-      content.innerHTML = `<div>Verbinde dein Bankkonto unter Einstellungen \u2192 Integrationen \u2192 Finance.</div>`;
-      return;
-    }
-
-    // Clear loading state and build component tree
-    content.className = "";
-    content.innerHTML = "";
-
     // Update header timestamp, rate limit, and demo state
     const header = this.shadowRoot.querySelector("fd-header");
     if (header) {
@@ -126,6 +116,50 @@ class FinanceDashboardPanel extends HTMLElement {
       header.rateLimitedUntil = data.rateLimitedUntil;
       if (data.demoMode !== undefined) header.demoMode = data.demoMode;
     }
+
+    // Loading state (e.g. during demo toggle)
+    if (data.loading) return;
+
+    if (data.error) {
+      content.className = "error";
+      content.innerHTML = `<div>Verbinde dein Bankkonto unter Einstellungen \u2192 Integrationen \u2192 Finance.</div>`;
+      return;
+    }
+
+    // Onboarding: no accounts and no demo → show welcome with demo CTA
+    if (data.accountCount === 0 && !data.demoMode) {
+      content.className = "";
+      content.innerHTML = `
+<div style="text-align:center;padding:60px 20px;max-width:480px;margin:0 auto;">
+  <div style="font-size:48px;margin-bottom:16px;">&#x1F3E6;</div>
+  <h2 style="margin:0 0 8px;font-size:20px;font-weight:600;">Willkommen beim Finance Dashboard</h2>
+  <p style="color:var(--tx2);margin:0 0 24px;line-height:1.5;">
+    Noch keine Bankkonten verbunden. Starte den Demo-Modus um das Dashboard mit Beispieldaten zu erkunden, oder verbinde dein Bankkonto unter Einstellungen.
+  </p>
+  <button id="onboardingDemoBtn" style="
+    padding:12px 28px;border-radius:12px;border:2px solid #f39c12;
+    background:#f39c12;color:#0a0a0f;font-size:15px;font-weight:700;
+    cursor:pointer;font-family:inherit;margin-bottom:12px;
+  ">Demo starten</button>
+  <div style="margin-top:16px;">
+    <a href="/config/integrations" style="color:var(--tx2);font-size:13px;text-decoration:underline;">
+      Bankkonto verbinden \u2192
+    </a>
+  </div>
+</div>`;
+      content.querySelector("#onboardingDemoBtn")
+        .addEventListener("click", () => {
+          this.shadowRoot.dispatchEvent(new CustomEvent("fd-demo-toggle", {
+            bubbles: true,
+            composed: true,
+          }));
+        });
+      return;
+    }
+
+    // Clear loading state and build component tree
+    content.className = "";
+    content.innerHTML = "";
 
     // Stats row
     const statsRow = document.createElement("fd-stats-row");

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "cloud_polling",
   "requirements": [
     "cryptography>=42.0.0",
-    "ha-customapps>=0.1.0"
+    "ha-customapps>=0.3.0"
   ],
-  "version": "0.9.1"
+  "version": "0.9.2"
 }


### PR DESCRIPTION
## Summary
- Remove all automatic banking API calls (startup, entity changes) — data only refreshes when user clicks "Aktualisieren"
- Add onboarding welcome screen with prominent "Demo starten" button when no accounts connected
- Make Demo button visually prominent, show "Noch keine Daten" timestamp fallback

## Changes
- **Backend**: Coordinator startup uses `async_load_cached()` instead of `async_refresh()` — zero external API calls on HA start
- **Frontend**: `_rebuild()` no longer makes API fallback calls automatically — only on explicit user refresh
- **Frontend**: New onboarding state replaces infinite "Lade Finanzdaten..." spinner
- **Frontend**: Demo button gets visible background fill, timestamp shows fallback text

## Test plan
- [ ] Start HA — verify no Enable Banking API calls in logs
- [ ] Open Finance Dashboard without bank accounts — verify onboarding screen with Demo button
- [ ] Click "Demo starten" — verify demo mode activates
- [ ] Click "Aktualisieren" — verify API calls only happen now
- [ ] Check "Noch keine Daten" shows before first refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)