### PR TITLE
feat(frontend): inline bank wizard + entity detection fix

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,18 @@
 # Build Log
 
+## 0.10.0 — 2026-04-12
+Version: 0.10.0
+Branch: claude/sweet-nightingale
+PR: (pending)
+Changes:
+- feat(frontend): add inline bank connection wizard as modal overlay (4-step flow: institution search, bank authorization with polling, account assignment, success)
+- fix(frontend): replace fragile entity_id prefix matching with HA Entity Registry lookup — entities are now found by platform + unique_id regardless of HA-generated entity_ids
+- feat(frontend): add "+ Konto" button in header to open wizard from anywhere
+- refactor(frontend): replace onboarding "Einstellungen" link with inline "Bankkonto verbinden" button
+- fix(frontend): add 4s delay before refreshRegistry() after setup complete to wait for HA config entry reload
+- fix(frontend): add https scheme validation on auth URLs to prevent XSS via javascript: scheme
+- fix(frontend): update institution filter to only re-render list container (prevents cursor jump)
+
 ## 0.9.2 — 2026-04-11
 Version: 0.9.2
 Branch: claude/sharp-shockley

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,21 @@ All notable changes to the Finance will be documented in this file.
 ### Fixed
 - Handle loading state in _onData to prevent clearing content during demo toggle
 
+## [0.10.0] — 2026-04-12
+
+### Added
+- Add inline bank connection wizard as modal overlay (4-step flow: institution search, bank authorization with polling, account assignment, success)
+- Add "+ Konto" button in header to open wizard from anywhere
+
+### Changed
+- Replace onboarding "Einstellungen" link with inline "Bankkonto verbinden" button
+
+### Fixed
+- Replace fragile entity_id prefix matching with HA Entity Registry lookup — entities are now found by platform + unique_id regardless of HA-generated entity_ids
+- Add 4s delay before refreshRegistry() after setup complete to wait for HA config entry reload
+- Add https scheme validation on auth URLs to prevent XSS via javascript: scheme
+- Update institution filter to only re-render list container (prevents cursor jump)
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.9.2"
+VERSION = "0.10.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -5,11 +5,8 @@
  * one API call for household + recurring data. Dispatches a single
  * "fd-data-updated" CustomEvent whenever data changes.
  *
- * Entity sources:
- *   sensor.fd_*           — per-account balance + total balance
- *   sensor.fd_monthly_summary — income, expenses, categories, fixed/var
- *   number.fd_budget_*    — budget limits per category
- *   select.fd_split_model — household split model
+ * Entity discovery uses the HA Entity Registry (platform = "finance_dashboard")
+ * to reliably find our entities regardless of their generated entity_id.
  */
 
 const DEBOUNCE_MS = 200;
@@ -26,6 +23,9 @@ class FdDataProvider extends HTMLElement {
     this._loading = false;
     this._demoMode = false;
     this._demoToggling = false;
+    // Entity registry map: entity_id → unique_id (for our platform only)
+    this._entityMap = null;
+    this._registryLoading = false;
   }
 
   get data() {
@@ -38,11 +38,48 @@ class FdDataProvider extends HTMLElement {
 
   set hass(hass) {
     this._hass = hass;
+    // Load entity registry on first hass assignment
+    if (!this._entityMap && !this._registryLoading) {
+      this._loadEntityRegistry();
+    }
     // In demo mode, don't watch entity changes
     if (this._demoMode) return;
     // Debounce: hass changes many times per second
     clearTimeout(this._debounceTimer);
     this._debounceTimer = setTimeout(() => this._onHassChanged(), DEBOUNCE_MS);
+  }
+
+  /** Load entity registry and build lookup map for our integration. */
+  async _loadEntityRegistry() {
+    if (!this._hass || !this._hass.connection) return;
+    this._registryLoading = true;
+    try {
+      const registry = await this._hass.connection.sendMessagePromise({
+        type: "config/entity_registry/list",
+      });
+      this._entityMap = new Map();
+      for (const entry of registry) {
+        if (entry.platform === DOMAIN) {
+          this._entityMap.set(entry.entity_id, entry.unique_id);
+        }
+      }
+      // Trigger initial rebuild now that we know our entities
+      this._prevStateHash = "";
+      this._initialRebuildDone = false;
+      this._onHassChanged();
+    } catch (e) {
+      console.error("fd-data-provider: entity registry load failed:", e);
+      this._entityMap = new Map();
+    } finally {
+      this._registryLoading = false;
+    }
+  }
+
+  /** Refresh entity registry (e.g. after setup wizard completes). */
+  async refreshRegistry() {
+    this._entityMap = null;
+    this._registryLoading = false;
+    await this._loadEntityRegistry();
   }
 
   /** Toggle demo mode — fetches demo data from API. Guarded against rapid clicks. */
@@ -116,7 +153,7 @@ class FdDataProvider extends HTMLElement {
 
   /** Check if relevant entity states changed and rebuild if needed. */
   _onHassChanged() {
-    if (!this._hass) return;
+    if (!this._hass || !this._entityMap) return;
     const hash = this._computeStateHash();
     // First call must always trigger rebuild (even with empty hash)
     if (this._initialRebuildDone && hash === this._prevStateHash) return;
@@ -127,13 +164,12 @@ class FdDataProvider extends HTMLElement {
 
   /** Quick hash of relevant entity states to detect changes. */
   _computeStateHash() {
-    if (!this._hass || !this._hass.states) return "";
+    if (!this._hass || !this._hass.states || !this._entityMap) return "";
     const parts = [];
-    for (const [id, state] of Object.entries(this._hass.states)) {
-      if (id.startsWith("sensor.fd_") ||
-          id.startsWith("number.fd_budget_") ||
-          id.startsWith("select.fd_")) {
-        parts.push(`${id}=${state.state}|${state.last_updated}`);
+    for (const entityId of this._entityMap.keys()) {
+      const state = this._hass.states[entityId];
+      if (state) {
+        parts.push(`${entityId}=${state.state}|${state.last_updated}`);
       }
     }
     return parts.join(";");
@@ -175,53 +211,88 @@ class FdDataProvider extends HTMLElement {
         rateLimitedUntil: null,
       };
 
-      // 1. Read per-account balance sensors
-      for (const [id, entity] of Object.entries(this._hass.states)) {
-        if (!id.startsWith("sensor.fd_") || id === "sensor.fd_total_balance" ||
-            id === "sensor.fd_monthly_summary") continue;
+      // 1. Read entities using registry-based lookup
+      let totalEntityId = null;
+      let summaryEntityId = null;
 
-        const val = parseFloat(entity.state);
-        if (isNaN(val)) continue;
+      for (const [entityId, uniqueId] of this._entityMap.entries()) {
+        const state = this._hass.states[entityId];
+        if (!state) continue;
 
-        const attrs = entity.attributes || {};
-        data.accounts.push({
-          entityId: id,
-          name: attrs.custom_name || attrs.friendly_name || id,
-          institution: attrs.institution || "",
-          balance: val,
-          ibanMasked: attrs.iban_masked || "****",
-          currency: attrs.unit_of_measurement || "EUR",
-          person: attrs.person || "",
-        });
-        data.totalBalance += val;
-        data.accountCount++;
+        // Account balance sensors: unique_id = finance_dashboard_{id}_balance
+        // (excludes total_balance and monthly_summary)
+        if (uniqueId === `${DOMAIN}_total_balance`) {
+          totalEntityId = entityId;
+          continue;
+        }
+        if (uniqueId === `${DOMAIN}_monthly_summary`) {
+          summaryEntityId = entityId;
+          continue;
+        }
+        if (uniqueId.startsWith(`${DOMAIN}_`) && uniqueId.endsWith("_balance")) {
+          const val = parseFloat(state.state);
+          if (isNaN(val)) continue;
+          const attrs = state.attributes || {};
+          data.accounts.push({
+            entityId,
+            name: attrs.custom_name || attrs.friendly_name || entityId,
+            institution: attrs.institution || "",
+            balance: val,
+            ibanMasked: attrs.iban_masked || "****",
+            currency: attrs.unit_of_measurement || "EUR",
+            person: attrs.person || "",
+          });
+          data.totalBalance += val;
+          data.accountCount++;
+          continue;
+        }
+
+        // Budget numbers: unique_id = finance_dashboard_budget_{category}
+        if (uniqueId.startsWith(`${DOMAIN}_budget_`)) {
+          const cat = uniqueId.replace(`${DOMAIN}_budget_`, "");
+          const val = parseFloat(state.state);
+          if (!isNaN(val) && val > 0) {
+            data.budgets[cat] = val;
+          }
+          continue;
+        }
+
+        // Split model: unique_id = finance_dashboard_split_model
+        if (uniqueId === `${DOMAIN}_split_model`) {
+          data.splitModel = state.state || "proportional";
+          continue;
+        }
       }
 
       // 2. Read total balance sensor (may differ from sum due to rounding)
-      const totalEntity = this._hass.states["sensor.fd_total_balance"];
-      if (totalEntity && !isNaN(parseFloat(totalEntity.state))) {
-        data.totalBalance = parseFloat(totalEntity.state);
+      if (totalEntityId) {
+        const totalEntity = this._hass.states[totalEntityId];
+        if (totalEntity && !isNaN(parseFloat(totalEntity.state))) {
+          data.totalBalance = parseFloat(totalEntity.state);
+        }
       }
 
       // 3. Read monthly summary sensor
-      const summaryEntity = this._hass.states["sensor.fd_monthly_summary"];
-      if (summaryEntity) {
-        const sa = summaryEntity.attributes || {};
-        data.summary.totalIncome = sa.total_income || 0;
-        data.summary.totalExpenses = sa.total_expenses || 0;
-        data.summary.balance = parseFloat(summaryEntity.state) || 0;
-        data.summary.categories = sa.categories || {};
-        data.summary.transactionCount = sa.transaction_count || 0;
-        data.summary.fixedCosts = sa.fixed_costs || 0;
-        data.summary.variableCosts = sa.variable_costs || 0;
-        data.summary.month = sa.month || data.summary.month;
-        data.summary.year = sa.year || data.summary.year;
-        data.lastRefresh = sa.last_refresh || null;
-        data.rateLimitedUntil = sa.rate_limited_until || null;
+      if (summaryEntityId) {
+        const summaryEntity = this._hass.states[summaryEntityId];
+        if (summaryEntity) {
+          const sa = summaryEntity.attributes || {};
+          data.summary.totalIncome = sa.total_income || 0;
+          data.summary.totalExpenses = sa.total_expenses || 0;
+          data.summary.balance = parseFloat(summaryEntity.state) || 0;
+          data.summary.categories = sa.categories || {};
+          data.summary.transactionCount = sa.transaction_count || 0;
+          data.summary.fixedCosts = sa.fixed_costs || 0;
+          data.summary.variableCosts = sa.variable_costs || 0;
+          data.summary.month = sa.month || data.summary.month;
+          data.summary.year = sa.year || data.summary.year;
+          data.lastRefresh = sa.last_refresh || null;
+          data.rateLimitedUntil = sa.rate_limited_until || null;
 
-        // Household and recurring from entity attrs (added in v0.7.9+)
-        if (sa.household) data.household = sa.household;
-        if (sa.recurring) data.recurring = sa.recurring;
+          // Household and recurring from entity attrs (added in v0.7.9+)
+          if (sa.household) data.household = sa.household;
+          if (sa.recurring) data.recurring = sa.recurring;
+        }
       }
 
       // 4. Fetch household/recurring from API ONLY on explicit user refresh
@@ -240,22 +311,6 @@ class FdDataProvider extends HTMLElement {
         } catch (e) {
           console.warn("fd-data-provider: API fallback for household/recurring failed:", e);
         }
-      }
-
-      // 5. Read budget entities
-      for (const [id, entity] of Object.entries(this._hass.states)) {
-        if (!id.startsWith("number.fd_budget_")) continue;
-        const cat = id.replace("number.fd_budget_", "");
-        const val = parseFloat(entity.state);
-        if (!isNaN(val) && val > 0) {
-          data.budgets[cat] = val;
-        }
-      }
-
-      // 6. Read split model
-      const splitEntity = this._hass.states["select.fd_split_model"];
-      if (splitEntity) {
-        data.splitModel = splitEntity.state || "proportional";
       }
 
       this._data = data;

--- a/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/custom_components/finance_dashboard/frontend/fd-header.js
@@ -183,6 +183,7 @@ h1 {
     <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
+    <button class="btn" id="addAccountBtn" title="Bankkonto hinzuf\u00fcgen">+ Konto</button>
   </div>
 </div>`;
 
@@ -197,6 +198,14 @@ h1 {
     this.shadowRoot.getElementById("demoBtn")
       .addEventListener("click", () => {
         this.dispatchEvent(new CustomEvent("fd-demo-toggle", {
+          bubbles: true,
+          composed: true,
+        }));
+      });
+
+    this.shadowRoot.getElementById("addAccountBtn")
+      .addEventListener("click", () => {
+        this.dispatchEvent(new CustomEvent("fd-open-wizard", {
           bubbles: true,
           composed: true,
         }));

--- a/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
+++ b/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
@@ -1,0 +1,679 @@
+/**
+ * fd-setup-wizard — Modal overlay for inline bank account connection.
+ *
+ * Steps:
+ *   1. Institution selection (search + select from Enable Banking list)
+ *   2. Authorization (open bank auth URL, poll for callback)
+ *   3. Account assignment (name, type, person per account)
+ *   4. Success confirmation
+ *
+ * Uses existing API endpoints:
+ *   GET  setup/status
+ *   GET  setup/institutions
+ *   POST setup/authorize
+ *   GET  setup/status (poll for pending_accounts after callback)
+ *   POST setup/complete
+ *   GET  setup/users
+ *
+ * Events dispatched:
+ *   fd-setup-complete — Wizard finished successfully, data provider should refresh
+ *   fd-setup-closed   — Wizard closed (cancel or success)
+ */
+
+// DOMAIN is declared by fd-data-provider.js (loaded first, shared global scope)
+const POLL_INTERVAL_MS = 2000;
+const POLL_MAX_MS = 300000; // 5 minutes
+
+class FdSetupWizard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._step = 1; // 1=institutions, 2=authorize, 3=accounts, 4=done
+    this._institutions = [];
+    this._filteredInstitutions = [];
+    this._selectedInstitution = null;
+    this._authUrl = null;
+    this._pendingAccounts = [];
+    this._pollTimer = null;
+    this._error = null;
+    this._loading = false;
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+  }
+
+  connectedCallback() {
+    this._render();
+    this._loadInstitutions();
+  }
+
+  disconnectedCallback() {
+    this._stopPolling();
+  }
+
+  close() {
+    this._stopPolling();
+    this.dispatchEvent(new CustomEvent("fd-setup-closed", {
+      bubbles: true,
+      composed: true,
+    }));
+    this.remove();
+  }
+
+  async _loadInstitutions() {
+    if (!this._hass) return;
+    this._loading = true;
+    this._error = null;
+    this._renderContent();
+    try {
+      const result = await this._hass.callApi("GET", `${DOMAIN}/setup/institutions`);
+      if (result.error) {
+        this._error = result.error;
+      } else {
+        this._institutions = result.institutions || [];
+        this._filteredInstitutions = this._institutions;
+      }
+    } catch (e) {
+      this._error = "Banken konnten nicht geladen werden";
+    }
+    this._loading = false;
+    this._renderContent();
+  }
+
+  async _loadUsers() {
+    // Reserved for future HA user picker (currently person is free-text)
+  }
+
+  async _authorize(institution) {
+    this._selectedInstitution = institution;
+    this._loading = true;
+    this._error = null;
+    this._step = 2;
+    this._renderContent();
+
+    try {
+      const result = await this._hass.callApi("POST", `${DOMAIN}/setup/authorize`, {
+        institution_name: institution.name,
+        institution_id: institution.id || "",
+        institution_logo: institution.logo || "",
+      });
+      if (result.error) {
+        this._error = result.error;
+        this._loading = false;
+        this._renderContent();
+        return;
+      }
+      this._authUrl = result.auth_url;
+      this._loading = false;
+      this._renderContent();
+      // Open auth URL in new tab (only https/http)
+      if (/^https?:\/\//.test(this._authUrl)) {
+        window.open(this._authUrl, "_blank");
+      }
+      // Start polling for callback completion
+      this._startPolling();
+    } catch (e) {
+      this._error = "Autorisierung fehlgeschlagen";
+      this._loading = false;
+      this._renderContent();
+    }
+  }
+
+  _startPolling() {
+    const startTime = Date.now();
+    this._pollTimer = setInterval(async () => {
+      if (Date.now() - startTime > POLL_MAX_MS) {
+        this._stopPolling();
+        this._error = "Zeitlimit erreicht. Bitte erneut versuchen.";
+        this._renderContent();
+        return;
+      }
+      try {
+        const status = await this._hass.callApi("GET", `${DOMAIN}/setup/status`);
+        if (status.pending_accounts && status.pending_accounts.length > 0) {
+          this._stopPolling();
+          this._pendingAccounts = status.pending_accounts.map((acc) => ({
+            ...acc,
+            custom_name: acc.name || "",
+            type: "personal",
+            person: "",
+            ha_users: [],
+          }));
+          await this._loadUsers();
+          this._step = 3;
+          this._renderContent();
+        }
+      } catch (e) {
+        // Silently retry
+      }
+    }, POLL_INTERVAL_MS);
+  }
+
+  _stopPolling() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  }
+
+  async _completeSetup() {
+    this._loading = true;
+    this._error = null;
+    this._renderContent();
+
+    const accounts = this._pendingAccounts.map((acc) => ({
+      id: acc.id,
+      custom_name: acc.custom_name,
+      type: acc.type,
+      person: acc.person,
+      ha_users: acc.ha_users,
+    }));
+
+    try {
+      const result = await this._hass.callApi("POST", `${DOMAIN}/setup/complete`, {
+        accounts,
+      });
+      if (result.error) {
+        this._error = result.error;
+        this._loading = false;
+        this._renderContent();
+        return;
+      }
+      this._loading = false;
+      this._step = 4;
+      this._renderContent();
+      this.dispatchEvent(new CustomEvent("fd-setup-complete", {
+        bubbles: true,
+        composed: true,
+      }));
+    } catch (e) {
+      this._error = "Setup konnte nicht abgeschlossen werden";
+      this._loading = false;
+      this._renderContent();
+    }
+  }
+
+  _filterInstitutions(query) {
+    const q = query.toLowerCase().trim();
+    if (!q) {
+      this._filteredInstitutions = this._institutions;
+    } else {
+      this._filteredInstitutions = this._institutions.filter(
+        (i) => i.name.toLowerCase().includes(q)
+      );
+    }
+    // Update only the list container — don't replace the input (avoids cursor jump)
+    const list = this.shadowRoot.querySelector(".institution-list");
+    if (list) {
+      list.innerHTML = this._renderInstitutionList();
+      this._bindInstitutionClicks();
+    }
+  }
+
+  _render() {
+    this.shadowRoot.innerHTML = `
+<style>
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  backdrop-filter: blur(4px);
+}
+.modal {
+  position: relative;
+  width: 90%;
+  max-width: 520px;
+  max-height: 80vh;
+  background: var(--card-background-color, #12121a);
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.08);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--primary-text-color, #e0e0e0);
+}
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--secondary-text-color, #9898a8);
+  font-size: 22px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+.close-btn:hover { background: rgba(255,255,255,0.06); }
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+.steps {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.15);
+}
+.step-dot.active { background: var(--accent-color, #4ecca3); }
+.step-dot.done { background: var(--accent-color, #4ecca3); opacity: 0.5; }
+.search-input {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--primary-text-color, #e0e0e0);
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+  outline: none;
+  margin-bottom: 16px;
+}
+.search-input:focus { border-color: var(--accent-color, #4ecca3); }
+.search-input::placeholder { color: var(--secondary-text-color, #9898a8); }
+.institution-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.institution-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.institution-item:hover {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(255,255,255,0.08);
+}
+.institution-item img {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  object-fit: contain;
+  background: #fff;
+}
+.institution-item .name {
+  font-size: 14px;
+  font-weight: 500;
+}
+.error-msg {
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: rgba(231,76,60,0.1);
+  border: 1px solid rgba(231,76,60,0.3);
+  color: #e74c3c;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.loading-spinner {
+  text-align: center;
+  padding: 40px;
+  color: var(--secondary-text-color, #9898a8);
+}
+.auth-card {
+  text-align: center;
+  padding: 20px 0;
+}
+.auth-card p {
+  color: var(--secondary-text-color, #9898a8);
+  line-height: 1.5;
+  margin: 0 0 20px;
+}
+.auth-card .waiting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--accent-color, #4ecca3);
+  font-size: 13px;
+  margin-top: 20px;
+}
+.btn-primary {
+  display: inline-block;
+  padding: 12px 24px;
+  border-radius: 10px;
+  background: var(--accent-color, #4ecca3);
+  color: #0a0a0f;
+  font-size: 14px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: none;
+}
+.btn-primary:hover { opacity: 0.9; }
+.btn-primary:disabled { opacity: 0.5; cursor: default; }
+.btn-secondary {
+  padding: 10px 20px;
+  border-radius: 10px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.1);
+  color: var(--primary-text-color, #e0e0e0);
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.btn-secondary:hover { background: rgba(255,255,255,0.04); }
+.account-card {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.02);
+  margin-bottom: 12px;
+}
+.account-card .acc-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.account-card .acc-header img {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: contain;
+  background: #fff;
+}
+.account-card .acc-header .acc-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.account-card .acc-header .acc-iban {
+  font-size: 12px;
+  color: var(--secondary-text-color, #9898a8);
+}
+.form-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.form-row label {
+  font-size: 12px;
+  color: var(--secondary-text-color, #9898a8);
+  display: block;
+  margin-bottom: 4px;
+}
+.form-row input, .form-row select {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--primary-text-color, #e0e0e0);
+  font-size: 13px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+.form-row input:focus, .form-row select:focus {
+  outline: none;
+  border-color: var(--accent-color, #4ecca3);
+}
+.form-field { flex: 1; }
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+.success-card {
+  text-align: center;
+  padding: 30px 0;
+}
+.success-card .icon { font-size: 48px; margin-bottom: 16px; }
+.success-card h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+}
+.success-card p {
+  color: var(--secondary-text-color, #9898a8);
+  margin: 0 0 24px;
+}
+</style>
+<div class="backdrop"></div>
+<div class="modal">
+  <div class="modal-header">
+    <h2>Bankkonto verbinden</h2>
+    <button class="close-btn" id="closeBtn">&times;</button>
+  </div>
+  <div class="modal-body" id="body"></div>
+</div>`;
+
+    this.shadowRoot.querySelector(".backdrop")
+      .addEventListener("click", () => this.close());
+    this.shadowRoot.getElementById("closeBtn")
+      .addEventListener("click", () => this.close());
+
+    this._renderContent();
+  }
+
+  _renderContent() {
+    const body = this.shadowRoot.getElementById("body");
+    if (!body) return;
+
+    // Step indicators
+    const stepsHtml = `<div class="steps">
+      ${[1, 2, 3, 4].map((s) =>
+        `<div class="step-dot ${s === this._step ? "active" : s < this._step ? "done" : ""}"></div>`
+      ).join("")}
+    </div>`;
+
+    const errorHtml = this._error
+      ? `<div class="error-msg">${this._esc(this._error)}</div>`
+      : "";
+
+    if (this._step === 1) {
+      body.innerHTML = `${stepsHtml}${errorHtml}${this._renderStep1()}`;
+      this._bindStep1();
+    } else if (this._step === 2) {
+      body.innerHTML = `${stepsHtml}${errorHtml}${this._renderStep2()}`;
+    } else if (this._step === 3) {
+      body.innerHTML = `${stepsHtml}${errorHtml}${this._renderStep3()}`;
+      this._bindStep3();
+    } else if (this._step === 4) {
+      body.innerHTML = `${stepsHtml}${this._renderStep4()}`;
+      this._bindStep4();
+    }
+  }
+
+  _renderInstitutionList() {
+    const items = this._filteredInstitutions.map((inst) => `
+      <div class="institution-item" data-name="${this._esc(inst.name)}" data-id="${this._esc(inst.id || "")}" data-logo="${this._esc(inst.logo || "")}">
+        ${inst.logo ? `<img src="${this._esc(inst.logo)}" alt="">` : `<div style="width:32px;height:32px;border-radius:6px;background:#333;"></div>`}
+        <span class="name">${this._esc(inst.name)}</span>
+      </div>
+    `).join("");
+    return items || '<div style="padding:20px;text-align:center;color:var(--secondary-text-color);">Keine Banken gefunden</div>';
+  }
+
+  _bindInstitutionClicks() {
+    this.shadowRoot.querySelectorAll(".institution-item").forEach((el) => {
+      el.addEventListener("click", () => {
+        this._authorize({
+          name: el.dataset.name,
+          id: el.dataset.id,
+          logo: el.dataset.logo,
+        });
+      });
+    });
+  }
+
+  _renderStep1() {
+    if (this._loading) {
+      return `<div class="loading-spinner">Banken werden geladen\u2026</div>`;
+    }
+    return `
+      <input type="text" class="search-input" id="searchInput" placeholder="Bank suchen\u2026" autocomplete="off">
+      <div class="institution-list">${this._renderInstitutionList()}</div>
+    `;
+  }
+
+  _bindStep1() {
+    const input = this.shadowRoot.getElementById("searchInput");
+    if (input) {
+      input.addEventListener("input", (e) => this._filterInstitutions(e.target.value));
+      input.focus();
+    }
+    this._bindInstitutionClicks();
+  }
+
+  _renderStep2() {
+    if (this._loading) {
+      return `<div class="loading-spinner">Autorisierung wird vorbereitet\u2026</div>`;
+    }
+    const bankName = this._selectedInstitution ? this._selectedInstitution.name : "Bank";
+    return `
+      <div class="auth-card">
+        <p>Autorisiere den Zugriff bei <strong>${this._esc(bankName)}</strong>.<br>
+        Ein neues Fenster wurde ge\u00f6ffnet. Schlie\u00dfe es nach der Best\u00e4tigung.</p>
+        ${this._authUrl && /^https?:\/\//.test(this._authUrl) ? `<a href="${this._esc(this._authUrl)}" target="_blank" class="btn-primary">Erneut \u00f6ffnen</a>` : ""}
+        <div class="waiting">
+          <span>\u23f3</span>
+          <span>Warte auf Best\u00e4tigung von der Bank\u2026</span>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderStep3() {
+    const accountCards = this._pendingAccounts.map((acc, idx) => {
+      const iban = acc.iban || "";
+      const ibanMasked = iban.length >= 4 ? `****${iban.slice(-4)}` : "****";
+
+      return `
+        <div class="account-card" data-idx="${idx}">
+          <div class="acc-header">
+            ${acc.logo ? `<img src="${this._esc(acc.logo)}" alt="">` : ""}
+            <div>
+              <div class="acc-name">${this._esc(acc.name || "Konto")}</div>
+              <div class="acc-iban">${ibanMasked}</div>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label>Anzeigename</label>
+              <input type="text" data-field="custom_name" data-idx="${idx}" value="${this._esc(acc.custom_name)}" placeholder="${this._esc(acc.name)}">
+            </div>
+            <div class="form-field">
+              <label>Kontotyp</label>
+              <select data-field="type" data-idx="${idx}">
+                <option value="personal" ${acc.type === "personal" ? "selected" : ""}>Privat</option>
+                <option value="shared" ${acc.type === "shared" ? "selected" : ""}>Gemeinsam</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label>Person</label>
+              <input type="text" data-field="person" data-idx="${idx}" value="${this._esc(acc.person)}" placeholder="Name der Person">
+            </div>
+          </div>
+        </div>
+      `;
+    }).join("");
+
+    return `
+      <p style="margin:0 0 16px;color:var(--secondary-text-color);font-size:13px;">
+        ${this._pendingAccounts.length} Konto(en) gefunden. Weise sie zu:
+      </p>
+      ${accountCards}
+      <div class="actions">
+        <button class="btn-secondary" id="backBtn">Zur\u00fcck</button>
+        <button class="btn-primary" id="completeBtn">Verbinden</button>
+      </div>
+    `;
+  }
+
+  _bindStep3() {
+    // Input bindings for account fields
+    this.shadowRoot.querySelectorAll("[data-field]").forEach((el) => {
+      el.addEventListener("change", (e) => {
+        const idx = parseInt(e.target.dataset.idx);
+        const field = e.target.dataset.field;
+        if (this._pendingAccounts[idx]) {
+          this._pendingAccounts[idx][field] = e.target.value;
+        }
+      });
+      el.addEventListener("input", (e) => {
+        const idx = parseInt(e.target.dataset.idx);
+        const field = e.target.dataset.field;
+        if (this._pendingAccounts[idx]) {
+          this._pendingAccounts[idx][field] = e.target.value;
+        }
+      });
+    });
+
+    const backBtn = this.shadowRoot.getElementById("backBtn");
+    if (backBtn) {
+      backBtn.addEventListener("click", () => {
+        this._step = 1;
+        this._error = null;
+        this._renderContent();
+      });
+    }
+
+    const completeBtn = this.shadowRoot.getElementById("completeBtn");
+    if (completeBtn) {
+      completeBtn.addEventListener("click", () => this._completeSetup());
+    }
+  }
+
+  _renderStep4() {
+    const count = this._pendingAccounts.length;
+    return `
+      <div class="success-card">
+        <div class="icon">&#x2705;</div>
+        <h3>Verbindung erfolgreich</h3>
+        <p>${count} Konto(en) wurden verbunden. Die Daten werden jetzt geladen.</p>
+        <button class="btn-primary" id="doneBtn">Fertig</button>
+      </div>
+    `;
+  }
+
+  _bindStep4() {
+    const btn = this.shadowRoot.getElementById("doneBtn");
+    if (btn) btn.addEventListener("click", () => this.close());
+  }
+
+  _esc(s) {
+    if (!s) return "";
+    const d = document.createElement("div");
+    d.textContent = s;
+    return d.innerHTML;
+  }
+}
+
+customElements.define("fd-setup-wizard", FdSetupWizard);

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -103,6 +103,29 @@ class FinanceDashboardPanel extends HTMLElement {
         });
       }
     });
+
+    this.shadowRoot.addEventListener("fd-open-wizard", () => {
+      this._openSetupWizard();
+    });
+
+    this.shadowRoot.addEventListener("fd-setup-complete", () => {
+      // Delay registry refresh — HA reloads the config entry asynchronously
+      // after setup/complete (1s deferred_reload in api.py). Wait for it.
+      const dp = this.shadowRoot.querySelector("fd-data-provider");
+      if (dp) setTimeout(() => dp.refreshRegistry(), 4000);
+    });
+
+    this.shadowRoot.addEventListener("fd-setup-closed", () => {
+      // Wizard removed itself, nothing extra needed
+    });
+  }
+
+  _openSetupWizard() {
+    // Prevent duplicate wizard
+    if (this.shadowRoot.querySelector("fd-setup-wizard")) return;
+    const wizard = document.createElement("fd-setup-wizard");
+    wizard.hass = this._hass;
+    this.shadowRoot.appendChild(wizard);
   }
 
   _onData(data) {
@@ -122,11 +145,13 @@ class FinanceDashboardPanel extends HTMLElement {
 
     if (data.error) {
       content.className = "error";
-      content.innerHTML = `<div>Verbinde dein Bankkonto unter Einstellungen \u2192 Integrationen \u2192 Finance.</div>`;
+      content.innerHTML = `<div>Keine Verbindung m\u00f6glich. <button id="errorWizardBtn" style="background:none;border:none;color:var(--accent-color,#4ecca3);cursor:pointer;text-decoration:underline;font-size:inherit;font-family:inherit;">Bankkonto verbinden</button></div>`;
+      content.querySelector("#errorWizardBtn")
+        ?.addEventListener("click", () => this._openSetupWizard());
       return;
     }
 
-    // Onboarding: no accounts and no demo → show welcome with demo CTA
+    // Onboarding: no accounts and no demo → show welcome with inline wizard CTA
     if (data.accountCount === 0 && !data.demoMode) {
       content.className = "";
       content.innerHTML = `
@@ -134,19 +159,23 @@ class FinanceDashboardPanel extends HTMLElement {
   <div style="font-size:48px;margin-bottom:16px;">&#x1F3E6;</div>
   <h2 style="margin:0 0 8px;font-size:20px;font-weight:600;">Willkommen beim Finance Dashboard</h2>
   <p style="color:var(--tx2);margin:0 0 24px;line-height:1.5;">
-    Noch keine Bankkonten verbunden. Starte den Demo-Modus um das Dashboard mit Beispieldaten zu erkunden, oder verbinde dein Bankkonto unter Einstellungen.
+    Noch keine Bankkonten verbunden. Verbinde jetzt dein Konto oder starte den Demo-Modus.
   </p>
-  <button id="onboardingDemoBtn" style="
-    padding:12px 28px;border-radius:12px;border:2px solid #f39c12;
-    background:#f39c12;color:#0a0a0f;font-size:15px;font-weight:700;
+  <button id="onboardingConnectBtn" style="
+    padding:12px 28px;border-radius:12px;border:none;
+    background:var(--accent-color,#4ecca3);color:#0a0a0f;font-size:15px;font-weight:700;
     cursor:pointer;font-family:inherit;margin-bottom:12px;
-  ">Demo starten</button>
-  <div style="margin-top:16px;">
-    <a href="/config/integrations" style="color:var(--tx2);font-size:13px;text-decoration:underline;">
-      Bankkonto verbinden \u2192
-    </a>
+  ">Bankkonto verbinden</button>
+  <div style="margin-top:12px;">
+    <button id="onboardingDemoBtn" style="
+      padding:10px 24px;border-radius:10px;border:2px solid #f39c12;
+      background:transparent;color:#f39c12;font-size:14px;font-weight:600;
+      cursor:pointer;font-family:inherit;
+    ">Demo starten</button>
   </div>
 </div>`;
+      content.querySelector("#onboardingConnectBtn")
+        .addEventListener("click", () => this._openSetupWizard());
       content.querySelector("#onboardingDemoBtn")
         .addEventListener("click", () => {
           this.shadowRoot.dispatchEvent(new CustomEvent("fd-demo-toggle", {

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.9.2"
+  "version": "0.10.0"
 }

--- a/custom_components/finance_dashboard/panel.py
+++ b/custom_components/finance_dashboard/panel.py
@@ -34,6 +34,7 @@ LOVELACE_COMPONENTS = [
     f"{STATIC_BASE}/fd-recurring-list.js",
     f"{STATIC_BASE}/fd-budget-config.js",
     f"{STATIC_BASE}/fd-categorize.js",
+    f"{STATIC_BASE}/fd-setup-wizard.js",
     f"{STATIC_BASE}/finance-status-chip.js",
 ]
 

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 
 
+
+## 0.10.0
+- Add inline bank connection wizard as modal overlay (4-step flow: institution search, bank authorization with polling, account assignment, success)
+- Replace fragile entity_id prefix matching with HA Entity Registry lookup — entities are now found by platform + unique_id regardless of HA-generated entity_ids
+- Add "+ Konto" button in header to open wizard from anywhere
+- Replace onboarding "Einstellungen" link with inline "Bankkonto verbinden" button
+- Add 4s delay before refreshRegistry() after setup complete to wait for HA config entry reload
+- Add https scheme validation on auth URLs to prevent XSS via javascript: scheme
+- Update institution filter to only re-render list container (prevents cursor jump)
+
 ## 0.9.2
 - Remove automatic banking API calls on HA startup — coordinator now loads from cache only, no external calls until user clicks "Aktualisieren"
 - Remove _first_update force-refresh flag from coordinator — staleness check is sufficient

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.9.2"
+version: "0.10.0"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.9.2"
+VERSION = "0.10.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -5,11 +5,8 @@
  * one API call for household + recurring data. Dispatches a single
  * "fd-data-updated" CustomEvent whenever data changes.
  *
- * Entity sources:
- *   sensor.fd_*           — per-account balance + total balance
- *   sensor.fd_monthly_summary — income, expenses, categories, fixed/var
- *   number.fd_budget_*    — budget limits per category
- *   select.fd_split_model — household split model
+ * Entity discovery uses the HA Entity Registry (platform = "finance_dashboard")
+ * to reliably find our entities regardless of their generated entity_id.
  */
 
 const DEBOUNCE_MS = 200;
@@ -26,6 +23,9 @@ class FdDataProvider extends HTMLElement {
     this._loading = false;
     this._demoMode = false;
     this._demoToggling = false;
+    // Entity registry map: entity_id → unique_id (for our platform only)
+    this._entityMap = null;
+    this._registryLoading = false;
   }
 
   get data() {
@@ -38,11 +38,48 @@ class FdDataProvider extends HTMLElement {
 
   set hass(hass) {
     this._hass = hass;
+    // Load entity registry on first hass assignment
+    if (!this._entityMap && !this._registryLoading) {
+      this._loadEntityRegistry();
+    }
     // In demo mode, don't watch entity changes
     if (this._demoMode) return;
     // Debounce: hass changes many times per second
     clearTimeout(this._debounceTimer);
     this._debounceTimer = setTimeout(() => this._onHassChanged(), DEBOUNCE_MS);
+  }
+
+  /** Load entity registry and build lookup map for our integration. */
+  async _loadEntityRegistry() {
+    if (!this._hass || !this._hass.connection) return;
+    this._registryLoading = true;
+    try {
+      const registry = await this._hass.connection.sendMessagePromise({
+        type: "config/entity_registry/list",
+      });
+      this._entityMap = new Map();
+      for (const entry of registry) {
+        if (entry.platform === DOMAIN) {
+          this._entityMap.set(entry.entity_id, entry.unique_id);
+        }
+      }
+      // Trigger initial rebuild now that we know our entities
+      this._prevStateHash = "";
+      this._initialRebuildDone = false;
+      this._onHassChanged();
+    } catch (e) {
+      console.error("fd-data-provider: entity registry load failed:", e);
+      this._entityMap = new Map();
+    } finally {
+      this._registryLoading = false;
+    }
+  }
+
+  /** Refresh entity registry (e.g. after setup wizard completes). */
+  async refreshRegistry() {
+    this._entityMap = null;
+    this._registryLoading = false;
+    await this._loadEntityRegistry();
   }
 
   /** Toggle demo mode — fetches demo data from API. Guarded against rapid clicks. */
@@ -116,7 +153,7 @@ class FdDataProvider extends HTMLElement {
 
   /** Check if relevant entity states changed and rebuild if needed. */
   _onHassChanged() {
-    if (!this._hass) return;
+    if (!this._hass || !this._entityMap) return;
     const hash = this._computeStateHash();
     // First call must always trigger rebuild (even with empty hash)
     if (this._initialRebuildDone && hash === this._prevStateHash) return;
@@ -127,13 +164,12 @@ class FdDataProvider extends HTMLElement {
 
   /** Quick hash of relevant entity states to detect changes. */
   _computeStateHash() {
-    if (!this._hass || !this._hass.states) return "";
+    if (!this._hass || !this._hass.states || !this._entityMap) return "";
     const parts = [];
-    for (const [id, state] of Object.entries(this._hass.states)) {
-      if (id.startsWith("sensor.fd_") ||
-          id.startsWith("number.fd_budget_") ||
-          id.startsWith("select.fd_")) {
-        parts.push(`${id}=${state.state}|${state.last_updated}`);
+    for (const entityId of this._entityMap.keys()) {
+      const state = this._hass.states[entityId];
+      if (state) {
+        parts.push(`${entityId}=${state.state}|${state.last_updated}`);
       }
     }
     return parts.join(";");
@@ -175,53 +211,88 @@ class FdDataProvider extends HTMLElement {
         rateLimitedUntil: null,
       };
 
-      // 1. Read per-account balance sensors
-      for (const [id, entity] of Object.entries(this._hass.states)) {
-        if (!id.startsWith("sensor.fd_") || id === "sensor.fd_total_balance" ||
-            id === "sensor.fd_monthly_summary") continue;
+      // 1. Read entities using registry-based lookup
+      let totalEntityId = null;
+      let summaryEntityId = null;
 
-        const val = parseFloat(entity.state);
-        if (isNaN(val)) continue;
+      for (const [entityId, uniqueId] of this._entityMap.entries()) {
+        const state = this._hass.states[entityId];
+        if (!state) continue;
 
-        const attrs = entity.attributes || {};
-        data.accounts.push({
-          entityId: id,
-          name: attrs.custom_name || attrs.friendly_name || id,
-          institution: attrs.institution || "",
-          balance: val,
-          ibanMasked: attrs.iban_masked || "****",
-          currency: attrs.unit_of_measurement || "EUR",
-          person: attrs.person || "",
-        });
-        data.totalBalance += val;
-        data.accountCount++;
+        // Account balance sensors: unique_id = finance_dashboard_{id}_balance
+        // (excludes total_balance and monthly_summary)
+        if (uniqueId === `${DOMAIN}_total_balance`) {
+          totalEntityId = entityId;
+          continue;
+        }
+        if (uniqueId === `${DOMAIN}_monthly_summary`) {
+          summaryEntityId = entityId;
+          continue;
+        }
+        if (uniqueId.startsWith(`${DOMAIN}_`) && uniqueId.endsWith("_balance")) {
+          const val = parseFloat(state.state);
+          if (isNaN(val)) continue;
+          const attrs = state.attributes || {};
+          data.accounts.push({
+            entityId,
+            name: attrs.custom_name || attrs.friendly_name || entityId,
+            institution: attrs.institution || "",
+            balance: val,
+            ibanMasked: attrs.iban_masked || "****",
+            currency: attrs.unit_of_measurement || "EUR",
+            person: attrs.person || "",
+          });
+          data.totalBalance += val;
+          data.accountCount++;
+          continue;
+        }
+
+        // Budget numbers: unique_id = finance_dashboard_budget_{category}
+        if (uniqueId.startsWith(`${DOMAIN}_budget_`)) {
+          const cat = uniqueId.replace(`${DOMAIN}_budget_`, "");
+          const val = parseFloat(state.state);
+          if (!isNaN(val) && val > 0) {
+            data.budgets[cat] = val;
+          }
+          continue;
+        }
+
+        // Split model: unique_id = finance_dashboard_split_model
+        if (uniqueId === `${DOMAIN}_split_model`) {
+          data.splitModel = state.state || "proportional";
+          continue;
+        }
       }
 
       // 2. Read total balance sensor (may differ from sum due to rounding)
-      const totalEntity = this._hass.states["sensor.fd_total_balance"];
-      if (totalEntity && !isNaN(parseFloat(totalEntity.state))) {
-        data.totalBalance = parseFloat(totalEntity.state);
+      if (totalEntityId) {
+        const totalEntity = this._hass.states[totalEntityId];
+        if (totalEntity && !isNaN(parseFloat(totalEntity.state))) {
+          data.totalBalance = parseFloat(totalEntity.state);
+        }
       }
 
       // 3. Read monthly summary sensor
-      const summaryEntity = this._hass.states["sensor.fd_monthly_summary"];
-      if (summaryEntity) {
-        const sa = summaryEntity.attributes || {};
-        data.summary.totalIncome = sa.total_income || 0;
-        data.summary.totalExpenses = sa.total_expenses || 0;
-        data.summary.balance = parseFloat(summaryEntity.state) || 0;
-        data.summary.categories = sa.categories || {};
-        data.summary.transactionCount = sa.transaction_count || 0;
-        data.summary.fixedCosts = sa.fixed_costs || 0;
-        data.summary.variableCosts = sa.variable_costs || 0;
-        data.summary.month = sa.month || data.summary.month;
-        data.summary.year = sa.year || data.summary.year;
-        data.lastRefresh = sa.last_refresh || null;
-        data.rateLimitedUntil = sa.rate_limited_until || null;
+      if (summaryEntityId) {
+        const summaryEntity = this._hass.states[summaryEntityId];
+        if (summaryEntity) {
+          const sa = summaryEntity.attributes || {};
+          data.summary.totalIncome = sa.total_income || 0;
+          data.summary.totalExpenses = sa.total_expenses || 0;
+          data.summary.balance = parseFloat(summaryEntity.state) || 0;
+          data.summary.categories = sa.categories || {};
+          data.summary.transactionCount = sa.transaction_count || 0;
+          data.summary.fixedCosts = sa.fixed_costs || 0;
+          data.summary.variableCosts = sa.variable_costs || 0;
+          data.summary.month = sa.month || data.summary.month;
+          data.summary.year = sa.year || data.summary.year;
+          data.lastRefresh = sa.last_refresh || null;
+          data.rateLimitedUntil = sa.rate_limited_until || null;
 
-        // Household and recurring from entity attrs (added in v0.7.9+)
-        if (sa.household) data.household = sa.household;
-        if (sa.recurring) data.recurring = sa.recurring;
+          // Household and recurring from entity attrs (added in v0.7.9+)
+          if (sa.household) data.household = sa.household;
+          if (sa.recurring) data.recurring = sa.recurring;
+        }
       }
 
       // 4. Fetch household/recurring from API ONLY on explicit user refresh
@@ -240,22 +311,6 @@ class FdDataProvider extends HTMLElement {
         } catch (e) {
           console.warn("fd-data-provider: API fallback for household/recurring failed:", e);
         }
-      }
-
-      // 5. Read budget entities
-      for (const [id, entity] of Object.entries(this._hass.states)) {
-        if (!id.startsWith("number.fd_budget_")) continue;
-        const cat = id.replace("number.fd_budget_", "");
-        const val = parseFloat(entity.state);
-        if (!isNaN(val) && val > 0) {
-          data.budgets[cat] = val;
-        }
-      }
-
-      // 6. Read split model
-      const splitEntity = this._hass.states["select.fd_split_model"];
-      if (splitEntity) {
-        data.splitModel = splitEntity.state || "proportional";
       }
 
       this._data = data;

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
@@ -183,6 +183,7 @@ h1 {
     <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
+    <button class="btn" id="addAccountBtn" title="Bankkonto hinzuf\u00fcgen">+ Konto</button>
   </div>
 </div>`;
 
@@ -197,6 +198,14 @@ h1 {
     this.shadowRoot.getElementById("demoBtn")
       .addEventListener("click", () => {
         this.dispatchEvent(new CustomEvent("fd-demo-toggle", {
+          bubbles: true,
+          composed: true,
+        }));
+      });
+
+    this.shadowRoot.getElementById("addAccountBtn")
+      .addEventListener("click", () => {
+        this.dispatchEvent(new CustomEvent("fd-open-wizard", {
           bubbles: true,
           composed: true,
         }));

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
@@ -1,0 +1,679 @@
+/**
+ * fd-setup-wizard — Modal overlay for inline bank account connection.
+ *
+ * Steps:
+ *   1. Institution selection (search + select from Enable Banking list)
+ *   2. Authorization (open bank auth URL, poll for callback)
+ *   3. Account assignment (name, type, person per account)
+ *   4. Success confirmation
+ *
+ * Uses existing API endpoints:
+ *   GET  setup/status
+ *   GET  setup/institutions
+ *   POST setup/authorize
+ *   GET  setup/status (poll for pending_accounts after callback)
+ *   POST setup/complete
+ *   GET  setup/users
+ *
+ * Events dispatched:
+ *   fd-setup-complete — Wizard finished successfully, data provider should refresh
+ *   fd-setup-closed   — Wizard closed (cancel or success)
+ */
+
+// DOMAIN is declared by fd-data-provider.js (loaded first, shared global scope)
+const POLL_INTERVAL_MS = 2000;
+const POLL_MAX_MS = 300000; // 5 minutes
+
+class FdSetupWizard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._step = 1; // 1=institutions, 2=authorize, 3=accounts, 4=done
+    this._institutions = [];
+    this._filteredInstitutions = [];
+    this._selectedInstitution = null;
+    this._authUrl = null;
+    this._pendingAccounts = [];
+    this._pollTimer = null;
+    this._error = null;
+    this._loading = false;
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+  }
+
+  connectedCallback() {
+    this._render();
+    this._loadInstitutions();
+  }
+
+  disconnectedCallback() {
+    this._stopPolling();
+  }
+
+  close() {
+    this._stopPolling();
+    this.dispatchEvent(new CustomEvent("fd-setup-closed", {
+      bubbles: true,
+      composed: true,
+    }));
+    this.remove();
+  }
+
+  async _loadInstitutions() {
+    if (!this._hass) return;
+    this._loading = true;
+    this._error = null;
+    this._renderContent();
+    try {
+      const result = await this._hass.callApi("GET", `${DOMAIN}/setup/institutions`);
+      if (result.error) {
+        this._error = result.error;
+      } else {
+        this._institutions = result.institutions || [];
+        this._filteredInstitutions = this._institutions;
+      }
+    } catch (e) {
+      this._error = "Banken konnten nicht geladen werden";
+    }
+    this._loading = false;
+    this._renderContent();
+  }
+
+  async _loadUsers() {
+    // Reserved for future HA user picker (currently person is free-text)
+  }
+
+  async _authorize(institution) {
+    this._selectedInstitution = institution;
+    this._loading = true;
+    this._error = null;
+    this._step = 2;
+    this._renderContent();
+
+    try {
+      const result = await this._hass.callApi("POST", `${DOMAIN}/setup/authorize`, {
+        institution_name: institution.name,
+        institution_id: institution.id || "",
+        institution_logo: institution.logo || "",
+      });
+      if (result.error) {
+        this._error = result.error;
+        this._loading = false;
+        this._renderContent();
+        return;
+      }
+      this._authUrl = result.auth_url;
+      this._loading = false;
+      this._renderContent();
+      // Open auth URL in new tab (only https/http)
+      if (/^https?:\/\//.test(this._authUrl)) {
+        window.open(this._authUrl, "_blank");
+      }
+      // Start polling for callback completion
+      this._startPolling();
+    } catch (e) {
+      this._error = "Autorisierung fehlgeschlagen";
+      this._loading = false;
+      this._renderContent();
+    }
+  }
+
+  _startPolling() {
+    const startTime = Date.now();
+    this._pollTimer = setInterval(async () => {
+      if (Date.now() - startTime > POLL_MAX_MS) {
+        this._stopPolling();
+        this._error = "Zeitlimit erreicht. Bitte erneut versuchen.";
+        this._renderContent();
+        return;
+      }
+      try {
+        const status = await this._hass.callApi("GET", `${DOMAIN}/setup/status`);
+        if (status.pending_accounts && status.pending_accounts.length > 0) {
+          this._stopPolling();
+          this._pendingAccounts = status.pending_accounts.map((acc) => ({
+            ...acc,
+            custom_name: acc.name || "",
+            type: "personal",
+            person: "",
+            ha_users: [],
+          }));
+          await this._loadUsers();
+          this._step = 3;
+          this._renderContent();
+        }
+      } catch (e) {
+        // Silently retry
+      }
+    }, POLL_INTERVAL_MS);
+  }
+
+  _stopPolling() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  }
+
+  async _completeSetup() {
+    this._loading = true;
+    this._error = null;
+    this._renderContent();
+
+    const accounts = this._pendingAccounts.map((acc) => ({
+      id: acc.id,
+      custom_name: acc.custom_name,
+      type: acc.type,
+      person: acc.person,
+      ha_users: acc.ha_users,
+    }));
+
+    try {
+      const result = await this._hass.callApi("POST", `${DOMAIN}/setup/complete`, {
+        accounts,
+      });
+      if (result.error) {
+        this._error = result.error;
+        this._loading = false;
+        this._renderContent();
+        return;
+      }
+      this._loading = false;
+      this._step = 4;
+      this._renderContent();
+      this.dispatchEvent(new CustomEvent("fd-setup-complete", {
+        bubbles: true,
+        composed: true,
+      }));
+    } catch (e) {
+      this._error = "Setup konnte nicht abgeschlossen werden";
+      this._loading = false;
+      this._renderContent();
+    }
+  }
+
+  _filterInstitutions(query) {
+    const q = query.toLowerCase().trim();
+    if (!q) {
+      this._filteredInstitutions = this._institutions;
+    } else {
+      this._filteredInstitutions = this._institutions.filter(
+        (i) => i.name.toLowerCase().includes(q)
+      );
+    }
+    // Update only the list container — don't replace the input (avoids cursor jump)
+    const list = this.shadowRoot.querySelector(".institution-list");
+    if (list) {
+      list.innerHTML = this._renderInstitutionList();
+      this._bindInstitutionClicks();
+    }
+  }
+
+  _render() {
+    this.shadowRoot.innerHTML = `
+<style>
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  backdrop-filter: blur(4px);
+}
+.modal {
+  position: relative;
+  width: 90%;
+  max-width: 520px;
+  max-height: 80vh;
+  background: var(--card-background-color, #12121a);
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.08);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--primary-text-color, #e0e0e0);
+}
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--secondary-text-color, #9898a8);
+  font-size: 22px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+.close-btn:hover { background: rgba(255,255,255,0.06); }
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+.steps {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.15);
+}
+.step-dot.active { background: var(--accent-color, #4ecca3); }
+.step-dot.done { background: var(--accent-color, #4ecca3); opacity: 0.5; }
+.search-input {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--primary-text-color, #e0e0e0);
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+  outline: none;
+  margin-bottom: 16px;
+}
+.search-input:focus { border-color: var(--accent-color, #4ecca3); }
+.search-input::placeholder { color: var(--secondary-text-color, #9898a8); }
+.institution-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.institution-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.institution-item:hover {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(255,255,255,0.08);
+}
+.institution-item img {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  object-fit: contain;
+  background: #fff;
+}
+.institution-item .name {
+  font-size: 14px;
+  font-weight: 500;
+}
+.error-msg {
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: rgba(231,76,60,0.1);
+  border: 1px solid rgba(231,76,60,0.3);
+  color: #e74c3c;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.loading-spinner {
+  text-align: center;
+  padding: 40px;
+  color: var(--secondary-text-color, #9898a8);
+}
+.auth-card {
+  text-align: center;
+  padding: 20px 0;
+}
+.auth-card p {
+  color: var(--secondary-text-color, #9898a8);
+  line-height: 1.5;
+  margin: 0 0 20px;
+}
+.auth-card .waiting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--accent-color, #4ecca3);
+  font-size: 13px;
+  margin-top: 20px;
+}
+.btn-primary {
+  display: inline-block;
+  padding: 12px 24px;
+  border-radius: 10px;
+  background: var(--accent-color, #4ecca3);
+  color: #0a0a0f;
+  font-size: 14px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: none;
+}
+.btn-primary:hover { opacity: 0.9; }
+.btn-primary:disabled { opacity: 0.5; cursor: default; }
+.btn-secondary {
+  padding: 10px 20px;
+  border-radius: 10px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.1);
+  color: var(--primary-text-color, #e0e0e0);
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.btn-secondary:hover { background: rgba(255,255,255,0.04); }
+.account-card {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.02);
+  margin-bottom: 12px;
+}
+.account-card .acc-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.account-card .acc-header img {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: contain;
+  background: #fff;
+}
+.account-card .acc-header .acc-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.account-card .acc-header .acc-iban {
+  font-size: 12px;
+  color: var(--secondary-text-color, #9898a8);
+}
+.form-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.form-row label {
+  font-size: 12px;
+  color: var(--secondary-text-color, #9898a8);
+  display: block;
+  margin-bottom: 4px;
+}
+.form-row input, .form-row select {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--primary-text-color, #e0e0e0);
+  font-size: 13px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+.form-row input:focus, .form-row select:focus {
+  outline: none;
+  border-color: var(--accent-color, #4ecca3);
+}
+.form-field { flex: 1; }
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+.success-card {
+  text-align: center;
+  padding: 30px 0;
+}
+.success-card .icon { font-size: 48px; margin-bottom: 16px; }
+.success-card h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+}
+.success-card p {
+  color: var(--secondary-text-color, #9898a8);
+  margin: 0 0 24px;
+}
+</style>
+<div class="backdrop"></div>
+<div class="modal">
+  <div class="modal-header">
+    <h2>Bankkonto verbinden</h2>
+    <button class="close-btn" id="closeBtn">&times;</button>
+  </div>
+  <div class="modal-body" id="body"></div>
+</div>`;
+
+    this.shadowRoot.querySelector(".backdrop")
+      .addEventListener("click", () => this.close());
+    this.shadowRoot.getElementById("closeBtn")
+      .addEventListener("click", () => this.close());
+
+    this._renderContent();
+  }
+
+  _renderContent() {
+    const body = this.shadowRoot.getElementById("body");
+    if (!body) return;
+
+    // Step indicators
+    const stepsHtml = `<div class="steps">
+      ${[1, 2, 3, 4].map((s) =>
+        `<div class="step-dot ${s === this._step ? "active" : s < this._step ? "done" : ""}"></div>`
+      ).join("")}
+    </div>`;
+
+    const errorHtml = this._error
+      ? `<div class="error-msg">${this._esc(this._error)}</div>`
+      : "";
+
+    if (this._step === 1) {
+      body.innerHTML = `${stepsHtml}${errorHtml}${this._renderStep1()}`;
+      this._bindStep1();
+    } else if (this._step === 2) {
+      body.innerHTML = `${stepsHtml}${errorHtml}${this._renderStep2()}`;
+    } else if (this._step === 3) {
+      body.innerHTML = `${stepsHtml}${errorHtml}${this._renderStep3()}`;
+      this._bindStep3();
+    } else if (this._step === 4) {
+      body.innerHTML = `${stepsHtml}${this._renderStep4()}`;
+      this._bindStep4();
+    }
+  }
+
+  _renderInstitutionList() {
+    const items = this._filteredInstitutions.map((inst) => `
+      <div class="institution-item" data-name="${this._esc(inst.name)}" data-id="${this._esc(inst.id || "")}" data-logo="${this._esc(inst.logo || "")}">
+        ${inst.logo ? `<img src="${this._esc(inst.logo)}" alt="">` : `<div style="width:32px;height:32px;border-radius:6px;background:#333;"></div>`}
+        <span class="name">${this._esc(inst.name)}</span>
+      </div>
+    `).join("");
+    return items || '<div style="padding:20px;text-align:center;color:var(--secondary-text-color);">Keine Banken gefunden</div>';
+  }
+
+  _bindInstitutionClicks() {
+    this.shadowRoot.querySelectorAll(".institution-item").forEach((el) => {
+      el.addEventListener("click", () => {
+        this._authorize({
+          name: el.dataset.name,
+          id: el.dataset.id,
+          logo: el.dataset.logo,
+        });
+      });
+    });
+  }
+
+  _renderStep1() {
+    if (this._loading) {
+      return `<div class="loading-spinner">Banken werden geladen\u2026</div>`;
+    }
+    return `
+      <input type="text" class="search-input" id="searchInput" placeholder="Bank suchen\u2026" autocomplete="off">
+      <div class="institution-list">${this._renderInstitutionList()}</div>
+    `;
+  }
+
+  _bindStep1() {
+    const input = this.shadowRoot.getElementById("searchInput");
+    if (input) {
+      input.addEventListener("input", (e) => this._filterInstitutions(e.target.value));
+      input.focus();
+    }
+    this._bindInstitutionClicks();
+  }
+
+  _renderStep2() {
+    if (this._loading) {
+      return `<div class="loading-spinner">Autorisierung wird vorbereitet\u2026</div>`;
+    }
+    const bankName = this._selectedInstitution ? this._selectedInstitution.name : "Bank";
+    return `
+      <div class="auth-card">
+        <p>Autorisiere den Zugriff bei <strong>${this._esc(bankName)}</strong>.<br>
+        Ein neues Fenster wurde ge\u00f6ffnet. Schlie\u00dfe es nach der Best\u00e4tigung.</p>
+        ${this._authUrl && /^https?:\/\//.test(this._authUrl) ? `<a href="${this._esc(this._authUrl)}" target="_blank" class="btn-primary">Erneut \u00f6ffnen</a>` : ""}
+        <div class="waiting">
+          <span>\u23f3</span>
+          <span>Warte auf Best\u00e4tigung von der Bank\u2026</span>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderStep3() {
+    const accountCards = this._pendingAccounts.map((acc, idx) => {
+      const iban = acc.iban || "";
+      const ibanMasked = iban.length >= 4 ? `****${iban.slice(-4)}` : "****";
+
+      return `
+        <div class="account-card" data-idx="${idx}">
+          <div class="acc-header">
+            ${acc.logo ? `<img src="${this._esc(acc.logo)}" alt="">` : ""}
+            <div>
+              <div class="acc-name">${this._esc(acc.name || "Konto")}</div>
+              <div class="acc-iban">${ibanMasked}</div>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label>Anzeigename</label>
+              <input type="text" data-field="custom_name" data-idx="${idx}" value="${this._esc(acc.custom_name)}" placeholder="${this._esc(acc.name)}">
+            </div>
+            <div class="form-field">
+              <label>Kontotyp</label>
+              <select data-field="type" data-idx="${idx}">
+                <option value="personal" ${acc.type === "personal" ? "selected" : ""}>Privat</option>
+                <option value="shared" ${acc.type === "shared" ? "selected" : ""}>Gemeinsam</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label>Person</label>
+              <input type="text" data-field="person" data-idx="${idx}" value="${this._esc(acc.person)}" placeholder="Name der Person">
+            </div>
+          </div>
+        </div>
+      `;
+    }).join("");
+
+    return `
+      <p style="margin:0 0 16px;color:var(--secondary-text-color);font-size:13px;">
+        ${this._pendingAccounts.length} Konto(en) gefunden. Weise sie zu:
+      </p>
+      ${accountCards}
+      <div class="actions">
+        <button class="btn-secondary" id="backBtn">Zur\u00fcck</button>
+        <button class="btn-primary" id="completeBtn">Verbinden</button>
+      </div>
+    `;
+  }
+
+  _bindStep3() {
+    // Input bindings for account fields
+    this.shadowRoot.querySelectorAll("[data-field]").forEach((el) => {
+      el.addEventListener("change", (e) => {
+        const idx = parseInt(e.target.dataset.idx);
+        const field = e.target.dataset.field;
+        if (this._pendingAccounts[idx]) {
+          this._pendingAccounts[idx][field] = e.target.value;
+        }
+      });
+      el.addEventListener("input", (e) => {
+        const idx = parseInt(e.target.dataset.idx);
+        const field = e.target.dataset.field;
+        if (this._pendingAccounts[idx]) {
+          this._pendingAccounts[idx][field] = e.target.value;
+        }
+      });
+    });
+
+    const backBtn = this.shadowRoot.getElementById("backBtn");
+    if (backBtn) {
+      backBtn.addEventListener("click", () => {
+        this._step = 1;
+        this._error = null;
+        this._renderContent();
+      });
+    }
+
+    const completeBtn = this.shadowRoot.getElementById("completeBtn");
+    if (completeBtn) {
+      completeBtn.addEventListener("click", () => this._completeSetup());
+    }
+  }
+
+  _renderStep4() {
+    const count = this._pendingAccounts.length;
+    return `
+      <div class="success-card">
+        <div class="icon">&#x2705;</div>
+        <h3>Verbindung erfolgreich</h3>
+        <p>${count} Konto(en) wurden verbunden. Die Daten werden jetzt geladen.</p>
+        <button class="btn-primary" id="doneBtn">Fertig</button>
+      </div>
+    `;
+  }
+
+  _bindStep4() {
+    const btn = this.shadowRoot.getElementById("doneBtn");
+    if (btn) btn.addEventListener("click", () => this.close());
+  }
+
+  _esc(s) {
+    if (!s) return "";
+    const d = document.createElement("div");
+    d.textContent = s;
+    return d.innerHTML;
+  }
+}
+
+customElements.define("fd-setup-wizard", FdSetupWizard);

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -103,6 +103,29 @@ class FinanceDashboardPanel extends HTMLElement {
         });
       }
     });
+
+    this.shadowRoot.addEventListener("fd-open-wizard", () => {
+      this._openSetupWizard();
+    });
+
+    this.shadowRoot.addEventListener("fd-setup-complete", () => {
+      // Delay registry refresh — HA reloads the config entry asynchronously
+      // after setup/complete (1s deferred_reload in api.py). Wait for it.
+      const dp = this.shadowRoot.querySelector("fd-data-provider");
+      if (dp) setTimeout(() => dp.refreshRegistry(), 4000);
+    });
+
+    this.shadowRoot.addEventListener("fd-setup-closed", () => {
+      // Wizard removed itself, nothing extra needed
+    });
+  }
+
+  _openSetupWizard() {
+    // Prevent duplicate wizard
+    if (this.shadowRoot.querySelector("fd-setup-wizard")) return;
+    const wizard = document.createElement("fd-setup-wizard");
+    wizard.hass = this._hass;
+    this.shadowRoot.appendChild(wizard);
   }
 
   _onData(data) {
@@ -122,11 +145,13 @@ class FinanceDashboardPanel extends HTMLElement {
 
     if (data.error) {
       content.className = "error";
-      content.innerHTML = `<div>Verbinde dein Bankkonto unter Einstellungen \u2192 Integrationen \u2192 Finance.</div>`;
+      content.innerHTML = `<div>Keine Verbindung m\u00f6glich. <button id="errorWizardBtn" style="background:none;border:none;color:var(--accent-color,#4ecca3);cursor:pointer;text-decoration:underline;font-size:inherit;font-family:inherit;">Bankkonto verbinden</button></div>`;
+      content.querySelector("#errorWizardBtn")
+        ?.addEventListener("click", () => this._openSetupWizard());
       return;
     }
 
-    // Onboarding: no accounts and no demo → show welcome with demo CTA
+    // Onboarding: no accounts and no demo → show welcome with inline wizard CTA
     if (data.accountCount === 0 && !data.demoMode) {
       content.className = "";
       content.innerHTML = `
@@ -134,19 +159,23 @@ class FinanceDashboardPanel extends HTMLElement {
   <div style="font-size:48px;margin-bottom:16px;">&#x1F3E6;</div>
   <h2 style="margin:0 0 8px;font-size:20px;font-weight:600;">Willkommen beim Finance Dashboard</h2>
   <p style="color:var(--tx2);margin:0 0 24px;line-height:1.5;">
-    Noch keine Bankkonten verbunden. Starte den Demo-Modus um das Dashboard mit Beispieldaten zu erkunden, oder verbinde dein Bankkonto unter Einstellungen.
+    Noch keine Bankkonten verbunden. Verbinde jetzt dein Konto oder starte den Demo-Modus.
   </p>
-  <button id="onboardingDemoBtn" style="
-    padding:12px 28px;border-radius:12px;border:2px solid #f39c12;
-    background:#f39c12;color:#0a0a0f;font-size:15px;font-weight:700;
+  <button id="onboardingConnectBtn" style="
+    padding:12px 28px;border-radius:12px;border:none;
+    background:var(--accent-color,#4ecca3);color:#0a0a0f;font-size:15px;font-weight:700;
     cursor:pointer;font-family:inherit;margin-bottom:12px;
-  ">Demo starten</button>
-  <div style="margin-top:16px;">
-    <a href="/config/integrations" style="color:var(--tx2);font-size:13px;text-decoration:underline;">
-      Bankkonto verbinden \u2192
-    </a>
+  ">Bankkonto verbinden</button>
+  <div style="margin-top:12px;">
+    <button id="onboardingDemoBtn" style="
+      padding:10px 24px;border-radius:10px;border:2px solid #f39c12;
+      background:transparent;color:#f39c12;font-size:14px;font-weight:600;
+      cursor:pointer;font-family:inherit;
+    ">Demo starten</button>
   </div>
 </div>`;
+      content.querySelector("#onboardingConnectBtn")
+        .addEventListener("click", () => this._openSetupWizard());
       content.querySelector("#onboardingDemoBtn")
         .addEventListener("click", () => {
           this.shadowRoot.dispatchEvent(new CustomEvent("fd-demo-toggle", {

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.9.2"
+  "version": "0.10.0"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
@@ -34,6 +34,7 @@ LOVELACE_COMPONENTS = [
     f"{STATIC_BASE}/fd-recurring-list.js",
     f"{STATIC_BASE}/fd-budget-config.js",
     f"{STATIC_BASE}/fd-categorize.js",
+    f"{STATIC_BASE}/fd-setup-wizard.js",
     f"{STATIC_BASE}/finance-status-chip.js",
 ]
 


### PR DESCRIPTION
## Summary\n- Replace fragile entity_id prefix matching with HA Entity Registry lookup — fixes 16 entities not being detected\n- Add inline bank connection wizard as modal overlay (institution search → authorization → account assignment → done)\n- Add \"+ Konto\" button in header, replace onboarding link with inline wizard CTA\n- XSS hardening on auth URLs, timing fix for post-setup registry refresh\n\n## Test plan\n- [ ] Open Finance panel with existing entities → dashboard renders data (not onboarding screen)\n- [ ] Click \"+ Konto\" → wizard modal opens with institution search\n- [ ] Search/filter institutions → list updates without cursor jump\n- [ ] Select bank → authorization flow starts, polls for callback\n- [ ] Complete setup → success screen, dashboard refreshes after ~4s\n- [ ] Onboarding screen (no accounts) shows \"Bankkonto verbinden\" button → opens wizard\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)