### PR TITLE
fix(setup): robust OAuth wizard + post-link auto-refresh

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,17 @@
 # Build Log
 
+## 0.10.1 — 2026-04-19
+Version: 0.10.1
+Branch: claude/pensive-rosalind-793ad9
+PR: (pending)
+Changes:
+- fix(setup): propagate OAuth callback errors through /setup/status so the wizard surfaces them within 2s instead of timing out after 5min
+- fix(setup): hard-fail /setup/authorize when callback URL is HTTP (Enable Banking requires pre-registered HTTPS redirect)
+- fix(setup): trigger one coordinator refresh after deferred entry reload so entities populate immediately after bank link
+- fix(core): raise Repairs issue on missing or invalid Enable Banking credentials, auto-clear on recovery
+- fix(frontend): wizard polling stops on setup_error and shows the message instead of waiting for timeout
+- fix(frontend): data provider subscribes to entity_registry_updated events so newly created sensors appear without race-prone 4s timer
+
 ## 0.10.0 — 2026-04-12
 Version: 0.10.0
 Branch: claude/sweet-nightingale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,16 @@ All notable changes to the Finance will be documented in this file.
 - Add https scheme validation on auth URLs to prevent XSS via javascript: scheme
 - Update institution filter to only re-render list container (prevents cursor jump)
 
+## [0.10.1] — 2026-04-19
+
+### Fixed
+- Propagate OAuth callback errors through /setup/status so the wizard surfaces them within 2s instead of timing out after 5min
+- Hard-fail /setup/authorize when callback URL is HTTP (Enable Banking requires pre-registered HTTPS redirect)
+- Trigger one coordinator refresh after deferred entry reload so entities populate immediately after bank link
+- Raise Repairs issue on missing or invalid Enable Banking credentials, auto-clear on recovery
+- Wizard polling stops on setup_error and shows the message instead of waiting for timeout
+- Data provider subscribes to entity_registry_updated events so newly created sensors appear without race-prone 4s timer
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/api.py
+++ b/custom_components/finance_dashboard/api.py
@@ -98,6 +98,11 @@ class FinanceDashboardSetupStatusView(HomeAssistantView):
                 "person": acc.get("person", ""),
             })
 
+        # Surface any error from the OAuth callback so the wizard can
+        # stop polling and display a meaningful message instead of timing
+        # out after 5 minutes.
+        setup_error = hass.data.get(DOMAIN, {}).get("pending_setup_error")
+
         result = {
             "configured": configured,
             "has_entry": True,
@@ -108,6 +113,7 @@ class FinanceDashboardSetupStatusView(HomeAssistantView):
             "accounts": safe_accounts,
             "pending_auth_code": has_pending_code,
             "pending_accounts": pending_accounts,
+            "setup_error": setup_error,
         }
         return self.json(result)
 
@@ -257,6 +263,23 @@ class FinanceDashboardSetupAuthorizeView(HomeAssistantView):
                 callback_url,
             )
 
+            # Enable Banking demands the redirect URL is pre-registered
+            # in the application dashboard. Hard-fail early with a
+            # helpful message so the user knows what to fix instead of
+            # waiting 5 min for the wizard to time out.
+            if request.scheme != "https":
+                return self.json({
+                    "error": (
+                        "Bank-Autorisierung erfordert HTTPS. Aktuelle "
+                        f"Callback-URL '{callback_url}' ist HTTP — "
+                        "öffne das Finance-Panel über die HTTPS-URL "
+                        "deiner HA-Instanz (z. B. Nabu Casa) oder "
+                        "richte ein TLS-Zertifikat ein."
+                    ),
+                    "error_type": "callback_not_https",
+                    "callback_url": callback_url,
+                })
+
             valid_until = (
                 datetime.now(timezone.utc)
                 + timedelta(days=SESSION_MAX_DAYS)
@@ -292,9 +315,10 @@ class FinanceDashboardSetupAuthorizeView(HomeAssistantView):
                     "institution_logo", ""
                 ),
             }
-            # Clear any stale auth code
+            # Clear any stale auth code / error from previous attempts
             hass.data[DOMAIN].pop("pending_auth_code", None)
             hass.data[DOMAIN].pop("pending_accounts", None)
+            hass.data[DOMAIN].pop("pending_setup_error", None)
 
             return self.json({"auth_url": auth_url})
 
@@ -535,6 +559,11 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
             # response reaches the frontend before unload kills
             # the HTTP endpoints.  The frontend polls /setup/status
             # until configured=true after the reload completes.
+            # After reload, trigger ONE coordinator refresh so the
+            # newly created entities are populated immediately —
+            # without this the user sees "unavailable" until they
+            # click "Aktualisieren". This is a single user-initiated
+            # call (not a periodic auto-refresh).
             async def _deferred_reload() -> None:
                 import asyncio as _aio
 
@@ -545,6 +574,20 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
                     )
                 except Exception:
                     _LOGGER.exception("Deferred entry reload failed")
+                    return
+                try:
+                    coordinator = hass.data.get(DOMAIN, {}).get(
+                        f"{entry.entry_id}_coordinator"
+                    )
+                    if coordinator:
+                        await coordinator.async_refresh()
+                        _LOGGER.info(
+                            "Initial post-setup refresh completed"
+                        )
+                except Exception:
+                    _LOGGER.exception(
+                        "Initial post-setup refresh failed"
+                    )
 
             hass.async_create_task(_deferred_reload())
 
@@ -661,7 +704,10 @@ class FinanceDashboardOAuthCallbackView(HomeAssistantView):
                 "pending_setup_auth"
             )
             if pending_setup:
-                # Panel flow — also fetch accounts for the wizard
+                # Panel flow — also fetch accounts for the wizard.
+                # On failure, store the error so /setup/status can
+                # surface it to the wizard (which polls until it sees
+                # either pending_accounts OR setup_error).
                 try:
                     from .credential_manager import CredentialManager
 
@@ -671,7 +717,12 @@ class FinanceDashboardOAuthCallbackView(HomeAssistantView):
                         await cred_mgr.async_get_api_credentials()
                     )
 
-                    if credentials:
+                    if not credentials:
+                        hass.data[DOMAIN]["pending_setup_error"] = (
+                            "Keine API-Credentials gespeichert — "
+                            "Integration neu einrichten."
+                        )
+                    else:
                         from .enablebanking_client import (
                             EnableBankingClient,
                         )
@@ -683,15 +734,26 @@ class FinanceDashboardOAuthCallbackView(HomeAssistantView):
                         session_data = (
                             await client.async_create_session(code)
                         )
-                        hass.data[DOMAIN]["pending_accounts"] = (
-                            session_data.get("accounts", [])
-                        )
-                        hass.data[DOMAIN]["pending_session_id"] = (
-                            session_data.get("session_id", "")
-                        )
-                except Exception:
+                        accounts = session_data.get("accounts", [])
+                        if not accounts:
+                            hass.data[DOMAIN]["pending_setup_error"] = (
+                                "Bank hat keine Konten zurückgegeben. "
+                                "Bitte Bankvertrag/Konsent prüfen."
+                            )
+                        else:
+                            hass.data[DOMAIN]["pending_accounts"] = (
+                                accounts
+                            )
+                            hass.data[DOMAIN]["pending_session_id"] = (
+                                session_data.get("session_id", "")
+                            )
+                except Exception as exc:
                     _LOGGER.exception(
                         "Failed to fetch accounts after OAuth callback"
+                    )
+                    hass.data[DOMAIN]["pending_setup_error"] = (
+                        f"Session-Erstellung fehlgeschlagen: "
+                        f"{str(exc)[:300]}"
                     )
             else:
                 # Legacy config flow — resume it

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.10.0"
+VERSION = "0.10.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -26,6 +26,16 @@ class FdDataProvider extends HTMLElement {
     // Entity registry map: entity_id → unique_id (for our platform only)
     this._entityMap = null;
     this._registryLoading = false;
+    // Unsubscribe handle for entity_registry_updated subscription
+    this._registryUnsub = null;
+  }
+
+  disconnectedCallback() {
+    if (this._registryUnsub) {
+      try { this._registryUnsub(); } catch (e) { /* ignore */ }
+      this._registryUnsub = null;
+    }
+    clearTimeout(this._debounceTimer);
   }
 
   get data() {
@@ -67,11 +77,59 @@ class FdDataProvider extends HTMLElement {
       this._prevStateHash = "";
       this._initialRebuildDone = false;
       this._onHassChanged();
+      // Subscribe to registry changes so newly created entities (e.g.
+      // after setup wizard completion) are picked up automatically
+      // without depending on a fixed timer in the panel shell.
+      await this._subscribeRegistryUpdates();
     } catch (e) {
       console.error("fd-data-provider: entity registry load failed:", e);
       this._entityMap = new Map();
     } finally {
       this._registryLoading = false;
+    }
+  }
+
+  /** Subscribe to entity_registry_updated events for our platform. */
+  async _subscribeRegistryUpdates() {
+    if (this._registryUnsub || !this._hass || !this._hass.connection) return;
+    try {
+      this._registryUnsub = await this._hass.connection.subscribeEvents(
+        () => {
+          // Cheap reload — registry list calls are tiny
+          this._reloadRegistryFromEvent();
+        },
+        "entity_registry_updated",
+      );
+    } catch (e) {
+      console.warn("fd-data-provider: registry event subscribe failed:", e);
+    }
+  }
+
+  /** Re-fetch registry on update event (debounced via micro-task). */
+  async _reloadRegistryFromEvent() {
+    if (!this._hass || !this._hass.connection) return;
+    try {
+      const registry = await this._hass.connection.sendMessagePromise({
+        type: "config/entity_registry/list",
+      });
+      const next = new Map();
+      for (const entry of registry) {
+        if (entry.platform === DOMAIN) {
+          next.set(entry.entity_id, entry.unique_id);
+        }
+      }
+      // Only rebuild if the entity set actually changed
+      const changed =
+        !this._entityMap ||
+        next.size !== this._entityMap.size ||
+        [...next.keys()].some((k) => !this._entityMap.has(k));
+      this._entityMap = next;
+      if (changed) {
+        this._prevStateHash = "";
+        this._onHassChanged();
+      }
+    } catch (e) {
+      console.warn("fd-data-provider: registry reload failed:", e);
     }
   }
 

--- a/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
+++ b/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
@@ -132,6 +132,16 @@ class FdSetupWizard extends HTMLElement {
       }
       try {
         const status = await this._hass.callApi("GET", `${DOMAIN}/setup/status`);
+        // Backend reported a setup error during the OAuth callback —
+        // stop polling immediately and show it to the user instead of
+        // waiting for the 5-minute timeout.
+        if (status.setup_error) {
+          this._stopPolling();
+          this._error = status.setup_error;
+          this._step = 1;
+          this._renderContent();
+          return;
+        }
         if (status.pending_accounts && status.pending_accounts.length > 0) {
           this._stopPolling();
           this._pendingAccounts = status.pending_accounts.map((acc) => ({

--- a/custom_components/finance_dashboard/manager.py
+++ b/custom_components/finance_dashboard/manager.py
@@ -615,14 +615,62 @@ class FinanceDashboardManager:
         creds = await self._credential_manager.async_get_api_credentials()
         if not creds:
             _LOGGER.error("No Enable Banking credentials available")
+            self._raise_credentials_issue("missing")
             return None
 
         from .enablebanking_client import EnableBankingClient
 
-        self._banking_client = EnableBankingClient(
-            creds["application_id"], creds["private_key_pem"]
-        )
+        try:
+            self._banking_client = EnableBankingClient(
+                creds["application_id"], creds["private_key_pem"]
+            )
+        except (ValueError, TypeError):
+            _LOGGER.exception(
+                "Enable Banking client init failed — PEM key invalid"
+            )
+            self._raise_credentials_issue("invalid_pem")
+            return None
+
+        # Successful client creation — clear any stale repair issue
+        self._clear_credentials_issue()
         return self._banking_client
+
+    def _raise_credentials_issue(self, kind: str) -> None:
+        """Surface credential problems via the Repairs flow."""
+        try:
+            from homeassistant.helpers import issue_registry as ir
+
+            translation_key = (
+                "credentials_missing"
+                if kind == "missing"
+                else "credentials_invalid_pem"
+            )
+            ir.async_create_issue(
+                self._hass,
+                DOMAIN,
+                f"credentials_{kind}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key=translation_key,
+                learn_more_url=(
+                    "https://enablebanking.com/docs/api/reference/"
+                ),
+            )
+        except Exception:
+            _LOGGER.debug("Could not create credentials repair issue",
+                          exc_info=True)
+
+    def _clear_credentials_issue(self) -> None:
+        """Remove credential-related repair issues after recovery."""
+        try:
+            from homeassistant.helpers import issue_registry as ir
+
+            for kind in ("missing", "invalid_pem"):
+                ir.async_delete_issue(
+                    self._hass, DOMAIN, f"credentials_{kind}"
+                )
+        except Exception:
+            pass
 
     async def async_confirm_transfer_chain(
         self, chain_id: str, confirmed: bool

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.10.0"
+  "version": "0.10.1"
 }

--- a/custom_components/finance_dashboard/strings.json
+++ b/custom_components/finance_dashboard/strings.json
@@ -70,6 +70,14 @@
     "reconfigure_required": {
       "title": "Finance: Reconfiguration Required",
       "description": "Finance has switched from GoCardless to Enable Banking. Please reconfigure with your Enable Banking credentials via Settings > Integrations."
+    },
+    "credentials_missing": {
+      "title": "Finance: API Credentials Missing",
+      "description": "No Enable Banking API credentials are stored. The integration cannot fetch banking data until you reconfigure it via Settings > Devices & Services."
+    },
+    "credentials_invalid_pem": {
+      "title": "Finance: Invalid Private Key",
+      "description": "The stored Enable Banking private key could not be loaded. Reconfigure the integration via Settings > Devices & Services and paste the full PEM key including the BEGIN/END lines."
     }
   }
 }

--- a/custom_components/finance_dashboard/translations/de.json
+++ b/custom_components/finance_dashboard/translations/de.json
@@ -70,6 +70,14 @@
     "reconfigure_required": {
       "title": "Finance: Neukonfiguration erforderlich",
       "description": "Finance hat von GoCardless zu Enable Banking gewechselt. Bitte konfiguriere die Integration unter Einstellungen > Integrationen neu."
+    },
+    "credentials_missing": {
+      "title": "Finance: API-Credentials fehlen",
+      "description": "Es sind keine Enable-Banking-API-Credentials gespeichert. Die Integration kann keine Bankdaten abrufen, bis du sie unter Einstellungen > Geräte & Dienste neu einrichtest."
+    },
+    "credentials_invalid_pem": {
+      "title": "Finance: Privater Schlüssel ungültig",
+      "description": "Der gespeicherte Enable-Banking-Privatschlüssel konnte nicht geladen werden. Richte die Integration unter Einstellungen > Geräte & Dienste neu ein und füge den vollständigen PEM-Schlüssel inklusive der BEGIN/END-Zeilen ein."
     }
   }
 }

--- a/custom_components/finance_dashboard/translations/en.json
+++ b/custom_components/finance_dashboard/translations/en.json
@@ -70,6 +70,14 @@
     "reconfigure_required": {
       "title": "Finance: Reconfiguration Required",
       "description": "Finance has switched from GoCardless to Enable Banking. Please reconfigure with your Enable Banking credentials via Settings > Integrations."
+    },
+    "credentials_missing": {
+      "title": "Finance: API Credentials Missing",
+      "description": "No Enable Banking API credentials are stored. The integration cannot fetch banking data until you reconfigure it via Settings > Devices & Services."
+    },
+    "credentials_invalid_pem": {
+      "title": "Finance: Invalid Private Key",
+      "description": "The stored Enable Banking private key could not be loaded. Reconfigure the integration via Settings > Devices & Services and paste the full PEM key including the BEGIN/END lines."
     }
   }
 }

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -9,6 +9,15 @@
 
 
 
+
+## 0.10.1
+- Propagate OAuth callback errors through /setup/status so the wizard surfaces them within 2s instead of timing out after 5min
+- Hard-fail /setup/authorize when callback URL is HTTP (Enable Banking requires pre-registered HTTPS redirect)
+- Trigger one coordinator refresh after deferred entry reload so entities populate immediately after bank link
+- Raise Repairs issue on missing or invalid Enable Banking credentials, auto-clear on recovery
+- Wizard polling stops on setup_error and shows the message instead of waiting for timeout
+- Data provider subscribes to entity_registry_updated events so newly created sensors appear without race-prone 4s timer
+
 ## 0.10.0
 - Add inline bank connection wizard as modal overlay (4-step flow: institution search, bank authorization with polling, account assignment, success)
 - Replace fragile entity_id prefix matching with HA Entity Registry lookup — entities are now found by platform + unique_id regardless of HA-generated entity_ids

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.10.0"
+version: "0.10.1"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
@@ -98,6 +98,11 @@ class FinanceDashboardSetupStatusView(HomeAssistantView):
                 "person": acc.get("person", ""),
             })
 
+        # Surface any error from the OAuth callback so the wizard can
+        # stop polling and display a meaningful message instead of timing
+        # out after 5 minutes.
+        setup_error = hass.data.get(DOMAIN, {}).get("pending_setup_error")
+
         result = {
             "configured": configured,
             "has_entry": True,
@@ -108,6 +113,7 @@ class FinanceDashboardSetupStatusView(HomeAssistantView):
             "accounts": safe_accounts,
             "pending_auth_code": has_pending_code,
             "pending_accounts": pending_accounts,
+            "setup_error": setup_error,
         }
         return self.json(result)
 
@@ -257,6 +263,23 @@ class FinanceDashboardSetupAuthorizeView(HomeAssistantView):
                 callback_url,
             )
 
+            # Enable Banking demands the redirect URL is pre-registered
+            # in the application dashboard. Hard-fail early with a
+            # helpful message so the user knows what to fix instead of
+            # waiting 5 min for the wizard to time out.
+            if request.scheme != "https":
+                return self.json({
+                    "error": (
+                        "Bank-Autorisierung erfordert HTTPS. Aktuelle "
+                        f"Callback-URL '{callback_url}' ist HTTP — "
+                        "öffne das Finance-Panel über die HTTPS-URL "
+                        "deiner HA-Instanz (z. B. Nabu Casa) oder "
+                        "richte ein TLS-Zertifikat ein."
+                    ),
+                    "error_type": "callback_not_https",
+                    "callback_url": callback_url,
+                })
+
             valid_until = (
                 datetime.now(timezone.utc)
                 + timedelta(days=SESSION_MAX_DAYS)
@@ -292,9 +315,10 @@ class FinanceDashboardSetupAuthorizeView(HomeAssistantView):
                     "institution_logo", ""
                 ),
             }
-            # Clear any stale auth code
+            # Clear any stale auth code / error from previous attempts
             hass.data[DOMAIN].pop("pending_auth_code", None)
             hass.data[DOMAIN].pop("pending_accounts", None)
+            hass.data[DOMAIN].pop("pending_setup_error", None)
 
             return self.json({"auth_url": auth_url})
 
@@ -535,6 +559,11 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
             # response reaches the frontend before unload kills
             # the HTTP endpoints.  The frontend polls /setup/status
             # until configured=true after the reload completes.
+            # After reload, trigger ONE coordinator refresh so the
+            # newly created entities are populated immediately —
+            # without this the user sees "unavailable" until they
+            # click "Aktualisieren". This is a single user-initiated
+            # call (not a periodic auto-refresh).
             async def _deferred_reload() -> None:
                 import asyncio as _aio
 
@@ -545,6 +574,20 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
                     )
                 except Exception:
                     _LOGGER.exception("Deferred entry reload failed")
+                    return
+                try:
+                    coordinator = hass.data.get(DOMAIN, {}).get(
+                        f"{entry.entry_id}_coordinator"
+                    )
+                    if coordinator:
+                        await coordinator.async_refresh()
+                        _LOGGER.info(
+                            "Initial post-setup refresh completed"
+                        )
+                except Exception:
+                    _LOGGER.exception(
+                        "Initial post-setup refresh failed"
+                    )
 
             hass.async_create_task(_deferred_reload())
 
@@ -661,7 +704,10 @@ class FinanceDashboardOAuthCallbackView(HomeAssistantView):
                 "pending_setup_auth"
             )
             if pending_setup:
-                # Panel flow — also fetch accounts for the wizard
+                # Panel flow — also fetch accounts for the wizard.
+                # On failure, store the error so /setup/status can
+                # surface it to the wizard (which polls until it sees
+                # either pending_accounts OR setup_error).
                 try:
                     from .credential_manager import CredentialManager
 
@@ -671,7 +717,12 @@ class FinanceDashboardOAuthCallbackView(HomeAssistantView):
                         await cred_mgr.async_get_api_credentials()
                     )
 
-                    if credentials:
+                    if not credentials:
+                        hass.data[DOMAIN]["pending_setup_error"] = (
+                            "Keine API-Credentials gespeichert — "
+                            "Integration neu einrichten."
+                        )
+                    else:
                         from .enablebanking_client import (
                             EnableBankingClient,
                         )
@@ -683,15 +734,26 @@ class FinanceDashboardOAuthCallbackView(HomeAssistantView):
                         session_data = (
                             await client.async_create_session(code)
                         )
-                        hass.data[DOMAIN]["pending_accounts"] = (
-                            session_data.get("accounts", [])
-                        )
-                        hass.data[DOMAIN]["pending_session_id"] = (
-                            session_data.get("session_id", "")
-                        )
-                except Exception:
+                        accounts = session_data.get("accounts", [])
+                        if not accounts:
+                            hass.data[DOMAIN]["pending_setup_error"] = (
+                                "Bank hat keine Konten zurückgegeben. "
+                                "Bitte Bankvertrag/Konsent prüfen."
+                            )
+                        else:
+                            hass.data[DOMAIN]["pending_accounts"] = (
+                                accounts
+                            )
+                            hass.data[DOMAIN]["pending_session_id"] = (
+                                session_data.get("session_id", "")
+                            )
+                except Exception as exc:
                     _LOGGER.exception(
                         "Failed to fetch accounts after OAuth callback"
+                    )
+                    hass.data[DOMAIN]["pending_setup_error"] = (
+                        f"Session-Erstellung fehlgeschlagen: "
+                        f"{str(exc)[:300]}"
                     )
             else:
                 # Legacy config flow — resume it

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.10.0"
+VERSION = "0.10.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -26,6 +26,16 @@ class FdDataProvider extends HTMLElement {
     // Entity registry map: entity_id → unique_id (for our platform only)
     this._entityMap = null;
     this._registryLoading = false;
+    // Unsubscribe handle for entity_registry_updated subscription
+    this._registryUnsub = null;
+  }
+
+  disconnectedCallback() {
+    if (this._registryUnsub) {
+      try { this._registryUnsub(); } catch (e) { /* ignore */ }
+      this._registryUnsub = null;
+    }
+    clearTimeout(this._debounceTimer);
   }
 
   get data() {
@@ -67,11 +77,59 @@ class FdDataProvider extends HTMLElement {
       this._prevStateHash = "";
       this._initialRebuildDone = false;
       this._onHassChanged();
+      // Subscribe to registry changes so newly created entities (e.g.
+      // after setup wizard completion) are picked up automatically
+      // without depending on a fixed timer in the panel shell.
+      await this._subscribeRegistryUpdates();
     } catch (e) {
       console.error("fd-data-provider: entity registry load failed:", e);
       this._entityMap = new Map();
     } finally {
       this._registryLoading = false;
+    }
+  }
+
+  /** Subscribe to entity_registry_updated events for our platform. */
+  async _subscribeRegistryUpdates() {
+    if (this._registryUnsub || !this._hass || !this._hass.connection) return;
+    try {
+      this._registryUnsub = await this._hass.connection.subscribeEvents(
+        () => {
+          // Cheap reload — registry list calls are tiny
+          this._reloadRegistryFromEvent();
+        },
+        "entity_registry_updated",
+      );
+    } catch (e) {
+      console.warn("fd-data-provider: registry event subscribe failed:", e);
+    }
+  }
+
+  /** Re-fetch registry on update event (debounced via micro-task). */
+  async _reloadRegistryFromEvent() {
+    if (!this._hass || !this._hass.connection) return;
+    try {
+      const registry = await this._hass.connection.sendMessagePromise({
+        type: "config/entity_registry/list",
+      });
+      const next = new Map();
+      for (const entry of registry) {
+        if (entry.platform === DOMAIN) {
+          next.set(entry.entity_id, entry.unique_id);
+        }
+      }
+      // Only rebuild if the entity set actually changed
+      const changed =
+        !this._entityMap ||
+        next.size !== this._entityMap.size ||
+        [...next.keys()].some((k) => !this._entityMap.has(k));
+      this._entityMap = next;
+      if (changed) {
+        this._prevStateHash = "";
+        this._onHassChanged();
+      }
+    } catch (e) {
+      console.warn("fd-data-provider: registry reload failed:", e);
     }
   }
 

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-setup-wizard.js
@@ -132,6 +132,16 @@ class FdSetupWizard extends HTMLElement {
       }
       try {
         const status = await this._hass.callApi("GET", `${DOMAIN}/setup/status`);
+        // Backend reported a setup error during the OAuth callback —
+        // stop polling immediately and show it to the user instead of
+        // waiting for the 5-minute timeout.
+        if (status.setup_error) {
+          this._stopPolling();
+          this._error = status.setup_error;
+          this._step = 1;
+          this._renderContent();
+          return;
+        }
         if (status.pending_accounts && status.pending_accounts.length > 0) {
           this._stopPolling();
           this._pendingAccounts = status.pending_accounts.map((acc) => ({

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
@@ -615,14 +615,62 @@ class FinanceDashboardManager:
         creds = await self._credential_manager.async_get_api_credentials()
         if not creds:
             _LOGGER.error("No Enable Banking credentials available")
+            self._raise_credentials_issue("missing")
             return None
 
         from .enablebanking_client import EnableBankingClient
 
-        self._banking_client = EnableBankingClient(
-            creds["application_id"], creds["private_key_pem"]
-        )
+        try:
+            self._banking_client = EnableBankingClient(
+                creds["application_id"], creds["private_key_pem"]
+            )
+        except (ValueError, TypeError):
+            _LOGGER.exception(
+                "Enable Banking client init failed — PEM key invalid"
+            )
+            self._raise_credentials_issue("invalid_pem")
+            return None
+
+        # Successful client creation — clear any stale repair issue
+        self._clear_credentials_issue()
         return self._banking_client
+
+    def _raise_credentials_issue(self, kind: str) -> None:
+        """Surface credential problems via the Repairs flow."""
+        try:
+            from homeassistant.helpers import issue_registry as ir
+
+            translation_key = (
+                "credentials_missing"
+                if kind == "missing"
+                else "credentials_invalid_pem"
+            )
+            ir.async_create_issue(
+                self._hass,
+                DOMAIN,
+                f"credentials_{kind}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key=translation_key,
+                learn_more_url=(
+                    "https://enablebanking.com/docs/api/reference/"
+                ),
+            )
+        except Exception:
+            _LOGGER.debug("Could not create credentials repair issue",
+                          exc_info=True)
+
+    def _clear_credentials_issue(self) -> None:
+        """Remove credential-related repair issues after recovery."""
+        try:
+            from homeassistant.helpers import issue_registry as ir
+
+            for kind in ("missing", "invalid_pem"):
+                ir.async_delete_issue(
+                    self._hass, DOMAIN, f"credentials_{kind}"
+                )
+        except Exception:
+            pass
 
     async def async_confirm_transfer_chain(
         self, chain_id: str, confirmed: bool

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.10.0"
+  "version": "0.10.1"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/strings.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/strings.json
@@ -70,6 +70,14 @@
     "reconfigure_required": {
       "title": "Finance: Reconfiguration Required",
       "description": "Finance has switched from GoCardless to Enable Banking. Please reconfigure with your Enable Banking credentials via Settings > Integrations."
+    },
+    "credentials_missing": {
+      "title": "Finance: API Credentials Missing",
+      "description": "No Enable Banking API credentials are stored. The integration cannot fetch banking data until you reconfigure it via Settings > Devices & Services."
+    },
+    "credentials_invalid_pem": {
+      "title": "Finance: Invalid Private Key",
+      "description": "The stored Enable Banking private key could not be loaded. Reconfigure the integration via Settings > Devices & Services and paste the full PEM key including the BEGIN/END lines."
     }
   }
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/de.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/de.json
@@ -70,6 +70,14 @@
     "reconfigure_required": {
       "title": "Finance: Neukonfiguration erforderlich",
       "description": "Finance hat von GoCardless zu Enable Banking gewechselt. Bitte konfiguriere die Integration unter Einstellungen > Integrationen neu."
+    },
+    "credentials_missing": {
+      "title": "Finance: API-Credentials fehlen",
+      "description": "Es sind keine Enable-Banking-API-Credentials gespeichert. Die Integration kann keine Bankdaten abrufen, bis du sie unter Einstellungen > Geräte & Dienste neu einrichtest."
+    },
+    "credentials_invalid_pem": {
+      "title": "Finance: Privater Schlüssel ungültig",
+      "description": "Der gespeicherte Enable-Banking-Privatschlüssel konnte nicht geladen werden. Richte die Integration unter Einstellungen > Geräte & Dienste neu ein und füge den vollständigen PEM-Schlüssel inklusive der BEGIN/END-Zeilen ein."
     }
   }
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/en.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/translations/en.json
@@ -70,6 +70,14 @@
     "reconfigure_required": {
       "title": "Finance: Reconfiguration Required",
       "description": "Finance has switched from GoCardless to Enable Banking. Please reconfigure with your Enable Banking credentials via Settings > Integrations."
+    },
+    "credentials_missing": {
+      "title": "Finance: API Credentials Missing",
+      "description": "No Enable Banking API credentials are stored. The integration cannot fetch banking data until you reconfigure it via Settings > Devices & Services."
+    },
+    "credentials_invalid_pem": {
+      "title": "Finance: Invalid Private Key",
+      "description": "The stored Enable Banking private key could not be loaded. Reconfigure the integration via Settings > Devices & Services and paste the full PEM key including the BEGIN/END lines."
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes 5 silent failure paths that made non-demo mode feel broken:

- Bank-link wizard now surfaces OAuth errors within ~2s instead of timing out after 5min
- HTTP callback URLs hard-fail with a helpful message (Enable Banking requires pre-registered HTTPS redirect)
- One coordinator refresh fires after `/setup/complete` so entities populate immediately
- Missing or invalid Enable Banking credentials raise a Repairs issue instead of silently returning empty data
- Frontend subscribes to `entity_registry_updated` instead of relying on a 4s timer after setup

Auto-refresh strategy unchanged: `update_interval=None`, manual refresh only, `.storage` cache survives restart.

## Test plan
- [ ] Restart HA / reload integration
- [ ] Open Finance panel → click "Bankkonto verbinden"
- [ ] On HTTP-only access: expect immediate hardfail with HTTPS hint
- [ ] After successful bank auth: account sensors populated without manual refresh click
- [ ] Simulate corrupted PEM via storage edit: Repairs issue appears under Settings → Repairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)