### PR TITLE
feat: user-feedback refresh + cache/live separation (v0.11.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ tokens.json
 htmlcov/
 .coverage
 .playwright-mcp/
+AUTONOMOUS-REPORT.html

--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,25 @@
 # Build Log
 
+## 0.11.0 — 2026-04-20
+Version: 0.11.0
+Branch: claude/bold-swirles-d0afe6
+PR: (pending)
+Changes:
+- fix(core): separate cache-reads from live API fetches — `manager.async_get_balance()` now returns cached balances only (was hitting Enable Banking on every HTTP `/balances` call, burning the 4/day/ASPSP rate limit)
+- feat(core): serialise user-triggered refreshes with `asyncio.Lock` to prevent double-click concurrent fetches
+- feat(core): persist `rate_limited_until` and `last_refresh_stats` across HA restart so the 4/day counter is not lost on reboot
+- feat(core): track structured refresh stats (outcome, accounts, transactions, new, duration_ms, errors) exposed via `manager.get_refresh_status()`
+- feat(api): new `POST /api/finance_dashboard/refresh` endpoint — the single user-triggered live-fetch entry point, returns stats synchronously
+- feat(api): new `GET /api/finance_dashboard/refresh_status` — cache-only polling endpoint, unbounded reads allowed
+- feat(core): `refresh_transactions` service now uses `SupportsResponse.OPTIONAL` and returns stats so automations can react to the outcome
+- feat(core): refresh_transactions refreshes balances in the same user-triggered round — one click, one cache update
+- feat(frontend): refresh button now shows a result toast ("5 Konten, 243 Transaktionen, 2 neu in 3.1s" / rate-limit / partial / error)
+- feat(frontend): header timestamp shows live cache age ("Zuletzt 14:23 · vor 2 Std") and updates every minute
+- feat(frontend): rate-limit and loading states surfaced clearly next to the refresh button instead of silent "Aktualisieren" reverts
+- fix(frontend): "Noch keine Daten" state now has explicit styling + hint to click Aktualisieren
+- refactor(coordinator): remove staleness-based auto-refresh — coordinator is now a pure cache projection, live fetches only via dedicated endpoint
+- docs(claude-md): replace stale GoCardless references with Enable Banking, document cache vs. live-fetch contract
+
 ## 0.10.1 — 2026-04-19
 Version: 0.10.1
 Branch: claude/pensive-rosalind-793ad9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,28 @@ All notable changes to the Finance will be documented in this file.
 - Wizard polling stops on setup_error and shows the message instead of waiting for timeout
 - Data provider subscribes to entity_registry_updated events so newly created sensors appear without race-prone 4s timer
 
+## [0.11.0] — 2026-04-20
+
+### Added
+- Serialise user-triggered refreshes with `asyncio.Lock` to prevent double-click concurrent fetches
+- Persist `rate_limited_until` and `last_refresh_stats` across HA restart so the 4/day counter is not lost on reboot
+- Track structured refresh stats (outcome, accounts, transactions, new, duration_ms, errors) exposed via `manager.get_refresh_status()`
+- New `POST /api/finance_dashboard/refresh` endpoint — the single user-triggered live-fetch entry point, returns stats synchronously
+- New `GET /api/finance_dashboard/refresh_status` — cache-only polling endpoint, unbounded reads allowed
+- `refresh_transactions` service now uses `SupportsResponse.OPTIONAL` and returns stats so automations can react to the outcome
+- Refresh_transactions refreshes balances in the same user-triggered round — one click, one cache update
+- Refresh button now shows a result toast ("5 Konten, 243 Transaktionen, 2 neu in 3.1s" / rate-limit / partial / error)
+- Header timestamp shows live cache age ("Zuletzt 14:23 · vor 2 Std") and updates every minute
+- Rate-limit and loading states surfaced clearly next to the refresh button instead of silent "Aktualisieren" reverts
+
+### Changed
+- Remove staleness-based auto-refresh — coordinator is now a pure cache projection, live fetches only via dedicated endpoint
+- Docs(claude-md): replace stale GoCardless references with Enable Banking, document cache vs. live-fetch contract
+
+### Fixed
+- Separate cache-reads from live API fetches — `manager.async_get_balance()` now returns cached balances only (was hitting Enable Banking on every HTTP `/balances` call, burning the 4/day/ASPSP rate limit)
+- "Noch keine Daten" state now has explicit styling + hint to click Aktualisieren
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@
 
 ## Project Overview
 
-A secure Home Assistant add-on and integration for personal finance management. Pulls live banking data via GoCardless (Nordigen) Open Banking API, auto-categorizes transactions, and provides household budget tracking with configurable multi-person split models.
+A secure Home Assistant add-on and integration for personal finance management. Pulls live banking data via the Enable Banking PSD2 Open Banking API (JWT-signed), auto-categorizes transactions, and provides household budget tracking with configurable multi-person split models.
+
+**Hard rule — cache vs. live fetch**: Cache reads (HTTP endpoints, sensor attributes, coordinator state) are unbounded. Live Enable-Banking calls are ONLY allowed from explicit user-triggered paths (refresh button, service call, setup bootstrap). Enable Banking enforces a 4/day ASPSP rate limit, so background polling is forbidden.
 
 ## Architecture
 
@@ -16,10 +18,11 @@ homeassistant-finance/
 │   ├── config_flow.py           # Config + Options + Reconfigure flows
 │   ├── const.py                 # All constants, categories, service names
 │   ├── manager.py               # Core orchestrator (accounts, transactions, summaries)
-│   ├── credential_manager.py    # Fernet encryption, token rotation, audit log
-│   ├── gocardless_client.py     # GoCardless Bank Account Data API v2 client
+│   ├── credential_manager.py    # Fernet encryption, JWT signing key, audit log
+│   ├── enablebanking_client.py  # Enable Banking API client (PSD2, JWT RS256)
+│   ├── coordinator.py           # DataUpdateCoordinator (cache-only reads)
 │   ├── categorizer.py           # Rule-based transaction auto-categorization
-│   ├── api.py                   # HTTP API endpoints (balances, transactions, summary)
+│   ├── api.py                   # HTTP endpoints (balances, transactions, summary, refresh, refresh_status)
 │   ├── panel.py                 # Sidebar panel registration
 │   ├── repairs.py               # Restart notification repair flow
 │   ├── services.yaml            # Service definitions for HA
@@ -45,12 +48,13 @@ homeassistant-finance/
 
 1. **No financial data in git**: Zero runtime data (balances, transactions, account numbers, tokens) may ever be committed. The `.gitignore` enforces this.
 2. **Encrypted storage**: All credentials use Fernet symmetric encryption (AES-128-CBC + HMAC) on top of HA's `.storage/` directory.
-3. **Token rotation**: GoCardless tokens are refreshed 1 hour before expiry. Forced re-auth after 90 days.
+3. **JWT auth**: Short-lived (60s) RS256-signed JWTs per request — no long-lived bearer tokens stored. RSA private key held only in memory. PSU session validity capped at 180 days (Enable Banking / EU RTS 2022/2360), forced re-auth after 90 days by policy.
 4. **Session timeouts**: Credential access times out after 30 minutes of inactivity.
 5. **Audit trail**: Every credential operation is logged (timestamp + event type only, never values).
 6. **IBAN masking**: API responses truncate IBANs to last 4 digits for frontend display.
 7. **Header security**: API endpoints require HA Bearer token authentication.
-8. **No external calls**: Only GoCardless API is contacted. No telemetry, no analytics.
+8. **No external calls**: Only the Enable Banking API is contacted. No telemetry, no analytics.
+9. **Rate-limit discipline**: Live fetches only on explicit user action. Cache-read endpoints (`/balances`, `/summary`, `/refresh_status`) never hit the bank.
 
 **Before every commit, verify:**
 - `git diff --cached` contains zero financial data (account numbers, balances, tokens)
@@ -60,8 +64,8 @@ homeassistant-finance/
 ## Tech Stack
 
 - **Language**: Python 3.12+ (integration), JavaScript (frontend)
-- **Banking API**: GoCardless (Nordigen) Open Banking API v2
-- **Encryption**: `cryptography` library (Fernet)
+- **Banking API**: Enable Banking (PSD2, JWT-signed, RS256). 4/day/ASPSP rate limit.
+- **Encryption**: `cryptography` library (Fernet for storage, RSA for JWT signing)
 - **Frontend**: Vanilla Web Components (Custom Elements API)
 - **HA APIs**: Config Entries, Services, HTTP Views, Repairs, Frontend Panel
 - **CI**: GitHub Actions (Python/JS syntax, version alignment, payload sync)
@@ -89,10 +93,22 @@ The add-on is a thin installer — it copies the integration code into HA's `cus
 - Falls back to persistent notification via HA Supervisor API
 
 ### Config Flow
-Three-step flow: `user` (API credentials) → `link_bank` (bank authorization) → `options` (settings). Real-time validation with GoCardless API call during setup.
+Three-step flow: `user` (Enable Banking application_id + RSA private key) → `link_bank` (ASPSP authorization via PSU redirect) → `options` (settings). Real-time validation via Enable Banking API call during setup.
 
 ### Service API
-7 Services: `refresh_accounts`, `refresh_transactions`, `get_balance`, `get_monthly_summary`, `categorize_transactions`, `set_budget_limit`, `export_csv`. All callable from HA automations.
+7 Services: `refresh_accounts`, `refresh_transactions` (both return refresh-stats dict via `SupportsResponse.OPTIONAL`), `get_balance`, `get_monthly_summary`, `categorize_transactions`, `set_budget_limit`, `export_csv`. `refresh_transactions` is the only live-fetch entry point and always updates balances + transactions + recurring in one atomic round.
+
+### Refresh Flow (user-triggered)
+1. Frontend refresh button → `POST /api/finance_dashboard/refresh`
+2. Endpoint calls `manager.async_refresh_transactions()` (async-lock-guarded)
+3. Manager hits Enable Banking for transactions + balances in one pass
+4. On HTTP 429 → `_rate_limited_until = midnight`, persisted across HA restart
+5. Stats (`outcome`, `accounts`, `transactions`, `new`, `duration_ms`, `errors`) written to cache
+6. Coordinator pushes updated state to sensors
+7. Endpoint returns `{ok, status: {stats, rate_limited_until, cache_age_seconds, ...}}`
+8. Frontend shows toast: "5 Konten, 243 Transaktionen, 2 neu in 3.1s" or the rate-limit message
+
+Cache-read endpoints (`/balances`, `/summary`, `/refresh_status`, `/transactions`) are unbounded and never hit the bank.
 
 ### Entity Architecture
 - **Sensor** (per account): `sensor.fd_{bank}_{account}` — balance with bank logo, IBAN masked
@@ -153,7 +169,7 @@ node --check custom_components/finance_dashboard/frontend/finance-dashboard-pane
 
 ### Phase 1 (Current) — Scaffold + MVP
 - [x] Repository structure mirroring YouTube Music Connector golden sample
-- [x] GoCardless API client skeleton
+- [x] Enable Banking API client (replaced GoCardless skeleton)
 - [x] Credential manager with encryption + audit
 - [x] Transaction categorizer (rule-based, 9 categories from household sheet)
 - [x] Companion add-on with smart installer
@@ -161,7 +177,7 @@ node --check custom_components/finance_dashboard/frontend/finance-dashboard-pane
 - [x] CI/CD pipeline
 - [x] Branding (dual-tone coin icon)
 - [x] Design sprint (requirements, architecture, UI mockups)
-- [ ] End-to-end GoCardless OAuth flow (DE banks only)
+- [ ] End-to-end Enable Banking OAuth flow (DE banks only)
 - [ ] Account balance sensors (1 per account, bank logo, optional aggregate)
 - [ ] Monthly summary sensor
 - [ ] Privacy-first API responses (IBAN masking, admin-only details)
@@ -208,7 +224,7 @@ node --check custom_components/finance_dashboard/frontend/finance-dashboard-pane
 
 | Module | Scope |
 |--------|-------|
-| `module:gocardless` | Banking API integration |
+| `module:enablebanking` | Banking API integration |
 | `module:categorizer` | Transaction categorization |
 | `module:household` | Multi-person budget model |
 | `module:frontend` | UI components |

--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -14,7 +14,7 @@ import logging
 from ha_customapps.restart import RestartNotifier
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 
 from .const import (
     DOMAIN,
@@ -140,13 +140,18 @@ async def _async_register_services(
         SERVICE_EXPORT_CSV,
     )
 
-    async def handle_refresh_accounts(call) -> None:
+    async def handle_refresh_accounts(call) -> dict:
         await manager.async_refresh_accounts()
+        return manager.get_refresh_status()
 
-    async def handle_refresh_transactions(call) -> None:
+    async def handle_refresh_transactions(call) -> dict:
+        """User-triggered refresh — returns stats so automations and
+        the frontend can surface "5 Konten, 243 Tx, 2 neu" instead
+        of a silent OK."""
         await manager.async_refresh_transactions()
         # Push fresh data to all entities via coordinator
         await coordinator.async_refresh()
+        return manager.get_refresh_status()
 
     async def handle_get_balance(call) -> dict:
         return await manager.async_get_balance()
@@ -177,10 +182,16 @@ async def _async_register_services(
         await coordinator.async_refresh()
 
     hass.services.async_register(
-        DOMAIN, SERVICE_REFRESH_ACCOUNTS, handle_refresh_accounts
+        DOMAIN,
+        SERVICE_REFRESH_ACCOUNTS,
+        handle_refresh_accounts,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_REFRESH_TRANSACTIONS, handle_refresh_transactions
+        DOMAIN,
+        SERVICE_REFRESH_TRANSACTIONS,
+        handle_refresh_transactions,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN, SERVICE_GET_BALANCE, handle_get_balance

--- a/custom_components/finance_dashboard/api.py
+++ b/custom_components/finance_dashboard/api.py
@@ -34,6 +34,8 @@ async def async_register_api(hass: HomeAssistant) -> None:
     hass.http.register_view(FinanceDashboardBalanceView())
     hass.http.register_view(FinanceDashboardTransactionsView())
     hass.http.register_view(FinanceDashboardSummaryView())
+    hass.http.register_view(FinanceDashboardRefreshStatusView())
+    hass.http.register_view(FinanceDashboardRefreshTriggerView())
     # Setup wizard endpoints
     hass.http.register_view(FinanceDashboardSetupStatusView())
     hass.http.register_view(FinanceDashboardSetupInstitutionsView())
@@ -1143,3 +1145,100 @@ class FinanceDashboardSummaryView(HomeAssistantView):
 
         summary = await manager.async_get_monthly_summary()
         return self.json(summary)
+
+
+class FinanceDashboardRefreshStatusView(HomeAssistantView):
+    """Cache-only refresh status — safe for unbounded polling.
+
+    Returns the snapshot produced by ``manager.get_refresh_status()``.
+    Used by the frontend to poll while a refresh is in flight and to
+    render cache-age + last-stats in the header without ever hitting
+    the banking API.
+    """
+
+    url = f"/api/{DOMAIN}/refresh_status"
+    name = f"api:{DOMAIN}:refresh_status"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return the current refresh snapshot (no API calls)."""
+        hass = request.app["hass"]
+        manager = _get_manager(hass)
+
+        if not manager:
+            return self.json(
+                {
+                    "is_refreshing": False,
+                    "has_cache": False,
+                    "error": "Not configured",
+                }
+            )
+
+        return self.json(manager.get_refresh_status())
+
+
+class FinanceDashboardRefreshTriggerView(HomeAssistantView):
+    """Explicit user-triggered refresh — the ONLY allowed live-fetch entry.
+
+    Blocks while the refresh is in flight and returns the final stats,
+    so the frontend can show a single "5 Konten, 243 Transaktionen"
+    toast instead of polling guesswork. Hard Rule: only invoked on
+    user-initiated actions (refresh button, manual service call).
+    """
+
+    url = f"/api/{DOMAIN}/refresh"
+    name = f"api:{DOMAIN}:refresh"
+    requires_auth = True
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Run a refresh and return the stats when it finishes."""
+        hass = request.app["hass"]
+        manager = _get_manager(hass)
+
+        if not manager:
+            return self.json(
+                {"error": "Not configured"}, status_code=404
+            )
+
+        # Short-circuit when already rate-limited so the UI can show a
+        # clear message instead of waiting for an HTTP 429 round-trip.
+        if manager.rate_limited_until:
+            return self.json(
+                {
+                    "ok": False,
+                    "reason": "rate_limited",
+                    "status": manager.get_refresh_status(),
+                }
+            )
+
+        try:
+            await manager.async_refresh_transactions()
+        except Exception as exc:
+            _LOGGER.exception("Refresh trigger failed")
+            return self.json(
+                {
+                    "ok": False,
+                    "reason": "error",
+                    "message": str(exc)[:200],
+                    "status": manager.get_refresh_status(),
+                }
+            )
+
+        # Also push fresh data through the coordinator so entity states
+        # update in lockstep with the user's click.
+        domain_data = hass.data.get(DOMAIN, {})
+        entry = domain_data.get("entry")
+        if entry:
+            coordinator = domain_data.get(
+                f"{entry.entry_id}_coordinator"
+            )
+            if coordinator:
+                try:
+                    await coordinator.async_refresh()
+                except Exception:
+                    _LOGGER.exception(
+                        "Coordinator refresh after live fetch failed"
+                    )
+
+        status = manager.get_refresh_status()
+        return self.json({"ok": True, "status": status})

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.10.1"
+VERSION = "0.11.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/coordinator.py
+++ b/custom_components/finance_dashboard/coordinator.py
@@ -73,14 +73,13 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
 
         This method is ONLY reached when the user explicitly triggers
         a refresh (UI button or service call). It never runs automatically.
+
+        Cache-read only: balances and summary are read from the manager's
+        in-memory cache — no live API calls. Live fetches happen inside
+        ``manager.async_refresh_transactions`` (which also refreshes
+        balances) and are gated by an explicit user trigger.
         """
         try:
-            # Refresh raw transactions only when the cache is stale.
-            last = self._manager._last_refresh
-            if last is None or (datetime.now() - last) > TRANSACTION_REFRESH_STALENESS:
-                _LOGGER.debug("Transaction cache stale — refreshing from API")
-                await self._manager.async_refresh_transactions()
-
             balances = await self._manager.async_get_balance()
             summary = await self._manager.async_get_monthly_summary()
 
@@ -88,7 +87,10 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
             return {
                 "balances": balances,
                 "summary": summary,
-                "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
+                "rate_limited_until": (
+                    rate_limited.isoformat() if rate_limited else None
+                ),
+                "refresh_status": self._manager.get_refresh_status(),
             }
         except Exception as exc:
             raise UpdateFailed(f"Finance data update failed: {exc}") from exc

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -190,23 +190,78 @@ class FdDataProvider extends HTMLElement {
     }
   }
 
-  /** Trigger a full data rebuild (manual refresh). */
+  /** Trigger a full data rebuild (manual refresh).
+   *
+   *  Returns a stats object the panel can surface in a toast:
+   *    { outcome, accounts, transactions, new, duration_ms, errors,
+   *      rate_limited_until, last_refresh, cache_age_seconds }
+   *
+   *  "outcome" is one of: ok | partial | rate_limited | error | demo.
+   */
   async refresh() {
-    if (!this._hass) return;
+    if (!this._hass) return { outcome: "error", errors: ["no hass"] };
     if (this._demoMode) {
-      // In demo mode, just regenerate demo data
       await this._loadDemoData();
-      return;
+      return { outcome: "demo" };
     }
-    // Ask HA to refresh transactions, which triggers coordinator update
+    // Notify listeners that a live fetch started — used by the header
+    // to show the spinner chip instead of the static timestamp.
+    this.dispatchEvent(new CustomEvent("fd-refresh-started", {
+      bubbles: true,
+      composed: true,
+    }));
+
+    let resultStatus = null;
     try {
-      await this._hass.callService(DOMAIN, "refresh_transactions");
+      // Dedicated endpoint blocks until the refresh completes and
+      // returns structured stats. Using this instead of the HA service
+      // call avoids the pre-2024 no-response behaviour on older cores.
+      const resp = await this._hass.callApi("POST", `${DOMAIN}/refresh`);
+      resultStatus = resp?.status || null;
+      if (resp && resp.ok === false) {
+        // Rate-limited or hard error — still dispatch the status so the
+        // header can render the "Morgen verfügbar" chip correctly.
+        this.dispatchEvent(new CustomEvent("fd-refresh-done", {
+          detail: {
+            status: resultStatus,
+            ok: false,
+            reason: resp.reason,
+          },
+          bubbles: true,
+          composed: true,
+        }));
+      }
     } catch (e) {
-      console.warn("fd-data-provider: refresh_transactions failed:", e);
+      console.warn("fd-data-provider: /refresh endpoint failed:", e);
     }
+
     // Force immediate rebuild — allow API fallback for household/recurring
     this._prevStateHash = "";
     await this._rebuild(true);
+
+    if (resultStatus && resultStatus.stats) {
+      this.dispatchEvent(new CustomEvent("fd-refresh-done", {
+        detail: {
+          status: resultStatus,
+          ok: resultStatus.stats.outcome === "ok",
+          reason: resultStatus.stats.outcome,
+        },
+        bubbles: true,
+        composed: true,
+      }));
+    }
+    return resultStatus || {};
+  }
+
+  /** Fetch the current refresh status (cache-only, unbounded-safe). */
+  async fetchRefreshStatus() {
+    if (!this._hass) return null;
+    try {
+      return await this._hass.callApi("GET", `${DOMAIN}/refresh_status`);
+    } catch (e) {
+      console.warn("fd-data-provider: /refresh_status failed:", e);
+      return null;
+    }
   }
 
   /** Check if relevant entity states changed and rebuild if needed. */
@@ -267,6 +322,8 @@ class FdDataProvider extends HTMLElement {
         error: null,
         lastRefresh: null,
         rateLimitedUntil: null,
+        lastRefreshStats: null,
+        isRefreshing: false,
       };
 
       // 1. Read entities using registry-based lookup
@@ -346,6 +403,8 @@ class FdDataProvider extends HTMLElement {
           data.summary.year = sa.year || data.summary.year;
           data.lastRefresh = sa.last_refresh || null;
           data.rateLimitedUntil = sa.rate_limited_until || null;
+          data.lastRefreshStats = sa.last_refresh_stats || null;
+          data.isRefreshing = !!sa.is_refreshing;
 
           // Household and recurring from entity attrs (added in v0.7.9+)
           if (sa.household) data.household = sa.household;

--- a/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/custom_components/finance_dashboard/frontend/fd-header.js
@@ -1,8 +1,12 @@
 /**
- * fd-header — Title bar with month selector, refresh button, and status chip.
+ * fd-header — Title bar with month selector, refresh button, status chip, toast.
  *
  * Properties:
- *   lastRefresh {string} — ISO timestamp of last data update
+ *   lastRefresh       {string} — ISO timestamp of last successful refresh
+ *   refreshing        {bool}   — live fetch in flight
+ *   rateLimitedUntil  {string} — ISO timestamp; if future, refresh is blocked
+ *   lastRefreshStats  {object} — {outcome, accounts, transactions, new, duration_ms, errors}
+ *   demoMode          {bool}
  *
  * Events dispatched:
  *   fd-refresh-requested — User clicked refresh button
@@ -16,21 +20,32 @@ class FdHeader extends HTMLElement {
     this._refreshing = false;
     this._rateLimitedUntil = null;
     this._demoMode = false;
+    this._lastRefreshStats = null;
+    this._timestampTimer = null;
+    this._toastTimer = null;
   }
 
   set lastRefresh(v) {
     this._lastRefresh = v;
     this._updateTimestamp();
+    this._scheduleTimestampTick();
   }
 
   set refreshing(v) {
     this._refreshing = v;
     this._updateRefreshBtn();
+    this._updateTimestamp();
   }
 
   set rateLimitedUntil(v) {
     this._rateLimitedUntil = v;
     this._updateRefreshBtn();
+    this._updateTimestamp();
+  }
+
+  set lastRefreshStats(v) {
+    this._lastRefreshStats = v;
+    this._updateTimestamp();
   }
 
   set demoMode(v) {
@@ -44,20 +59,44 @@ class FdHeader extends HTMLElement {
     if (this._rateLimitedUntil && new Date(this._rateLimitedUntil) > new Date()) {
       btn.disabled = true;
       btn.textContent = "Morgen verf\u00fcgbar";
-      btn.title = "Tageslimit der Bank-API erreicht. N\u00e4chste Aktualisierung ab morgen.";
+      btn.title = "Tageslimit der Bank-API erreicht (4/Tag pro Konto). N\u00e4chste Aktualisierung ab morgen.";
     } else if (this._refreshing) {
       btn.disabled = true;
-      btn.textContent = "Laden\u2026";
-      btn.title = "";
+      btn.textContent = "L\u00e4dt\u2026";
+      btn.title = "Bank-API wird abgefragt\u2014dies kann einige Sekunden dauern.";
     } else {
       btn.disabled = false;
       btn.textContent = "Aktualisieren";
-      btn.title = "";
+      btn.title = "Live-Daten von der Bank-API holen";
     }
   }
 
   connectedCallback() {
     this._render();
+  }
+
+  disconnectedCallback() {
+    if (this._timestampTimer) clearInterval(this._timestampTimer);
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+  }
+
+  _scheduleTimestampTick() {
+    // Once we have a timestamp, update the "vor N min" label every 60s
+    // so the user always sees the current cache age without reloading.
+    if (this._timestampTimer || !this._lastRefresh) return;
+    this._timestampTimer = setInterval(() => this._updateTimestamp(), 60000);
+  }
+
+  /** Public: show a toast with refresh results. */
+  showToast(message, kind) {
+    const toast = this.shadowRoot.getElementById("toast");
+    if (!toast) return;
+    toast.textContent = message;
+    toast.className = `toast toast-${kind || "info"} show`;
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+    this._toastTimer = setTimeout(() => {
+      toast.classList.remove("show");
+    }, kind === "error" ? 7000 : 4500);
   }
 
   _updateDemoBtn() {
@@ -166,6 +205,49 @@ h1 {
 .btn-demo-active:hover {
   background: #e67e22;
 }
+.ts-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  line-height: 1.2;
+}
+.ts-stats {
+  font-size: 10px;
+  color: var(--tx2);
+  opacity: 0.85;
+}
+.ts.loading { color: var(--ac); }
+.ts.empty   { color: var(--tx2); font-style: italic; }
+.ts.rate    { color: var(--demo); }
+
+/* Toast */
+.toast {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 2000;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  background: var(--sf);
+  color: var(--tx);
+  border: 1px solid var(--bd);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.25s, transform 0.25s;
+  max-width: 360px;
+  white-space: pre-wrap;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+.toast-success { border-color: var(--ac); }
+.toast-info    { border-color: rgba(78,204,163,0.3); }
+.toast-warn    { border-color: var(--demo); color: var(--demo); }
+.toast-error   { border-color: #e74c3c; color: #e74c3c; }
+
 @media (max-width: 600px) {
   .hdr { flex-wrap: wrap; gap: 10px; }
   .right { width: 100%; justify-content: flex-end; }
@@ -173,13 +255,17 @@ h1 {
   .btn { padding: 6px 10px; font-size: 12px; }
 }
 </style>
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
 <div class="hdr">
   <div class="title-row">
     <h1>Finance Dashboard</h1>
     <span class="demo-badge" id="demoBadge">DEMO</span>
   </div>
   <div class="right">
-    <span class="ts" id="ts">Noch keine Daten</span>
+    <div class="ts-stack">
+      <span class="ts empty" id="ts">Noch keine Daten \u2014 klicke "Aktualisieren"</span>
+      <span class="ts-stats" id="tsStats"></span>
+    </div>
     <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
@@ -217,11 +303,73 @@ h1 {
 
   _updateTimestamp() {
     const el = this.shadowRoot.getElementById("ts");
+    const statsEl = this.shadowRoot.getElementById("tsStats");
     if (!el) return;
+
+    // Refresh in flight takes priority over everything else.
+    if (this._refreshing) {
+      el.className = "ts loading";
+      el.textContent = "Aktualisiere\u2026 Bank-API wird abgefragt";
+      if (statsEl) statsEl.textContent = "";
+      return;
+    }
+
+    // Hard rate-limit state — surface it where the user looks first.
+    if (this._rateLimitedUntil && new Date(this._rateLimitedUntil) > new Date()) {
+      el.className = "ts rate";
+      el.textContent = "Tageslimit erreicht \u2014 Cache wird genutzt";
+      if (statsEl) {
+        const next = new Date(this._rateLimitedUntil);
+        statsEl.textContent = `Neue Abfragen ab ${next.toLocaleDateString("de-DE")} 00:00`;
+      }
+      return;
+    }
+
     if (this._lastRefresh) {
       const d = new Date(this._lastRefresh);
-      el.textContent = `Zuletzt: ${d.toLocaleTimeString("de-DE")}`;
+      const timeStr = d.toLocaleTimeString("de-DE", {
+        hour: "2-digit", minute: "2-digit",
+      });
+      const dayStr = d.toLocaleDateString("de-DE", {
+        day: "2-digit", month: "2-digit",
+      });
+      const ageMin = Math.max(0, Math.round((Date.now() - d.getTime()) / 60000));
+      let ageLabel;
+      if (ageMin < 1) ageLabel = "gerade eben";
+      else if (ageMin < 60) ageLabel = `vor ${ageMin} Min`;
+      else if (ageMin < 1440) {
+        const h = Math.round(ageMin / 60);
+        ageLabel = `vor ${h} Std`;
+      } else {
+        const days = Math.round(ageMin / 1440);
+        ageLabel = `vor ${days} Tg`;
+      }
+      el.className = "ts";
+      el.textContent = `Zuletzt: ${timeStr} (${ageLabel})`;
+      el.title = `Letzte Aktualisierung: ${dayStr} ${timeStr}`;
+
+      if (statsEl) {
+        const s = this._lastRefreshStats;
+        if (s && s.outcome) {
+          const parts = [];
+          if (s.accounts != null) parts.push(`${s.accounts} Konten`);
+          if (s.transactions != null) parts.push(`${s.transactions} Tx`);
+          if (s.new) parts.push(`${s.new} neu`);
+          if (s.outcome === "partial") parts.push("teilweise Fehler");
+          else if (s.outcome === "rate_limited") parts.push("Rate-Limit");
+          else if (s.outcome === "error") parts.push("Fehler");
+          statsEl.textContent = parts.join(" \u00b7 ");
+        } else {
+          statsEl.textContent = "";
+        }
+      }
+      return;
     }
+
+    // No cache at all.
+    el.className = "ts empty";
+    el.textContent = "Noch keine Daten \u2014 klicke \"Aktualisieren\"";
+    if (statsEl) statsEl.textContent = "";
   }
 }
 

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -84,6 +84,13 @@ class FinanceDashboardPanel extends HTMLElement {
       // but guard here as well.
       if (header && header._rateLimitedUntil &&
           new Date(header._rateLimitedUntil) > new Date()) {
+        if (header.showToast) {
+          header.showToast(
+            "Tageslimit der Bank-API ist erreicht (4/Tag pro Konto). "
+            + "Neue Abfragen sind erst ab morgen 00:00 m\u00f6glich.",
+            "warn",
+          );
+        }
         return;
       }
       if (header) header.refreshing = true;
@@ -91,6 +98,42 @@ class FinanceDashboardPanel extends HTMLElement {
         dp.refresh().finally(() => {
           if (header) header.refreshing = false;
         });
+      }
+    });
+
+    this.shadowRoot.addEventListener("fd-refresh-done", (e) => {
+      const header = this.shadowRoot.querySelector("fd-header");
+      if (!header || !header.showToast) return;
+      const d = e.detail || {};
+      const s = d.status?.stats || {};
+      const reason = d.reason || s.outcome || "error";
+      if (reason === "ok") {
+        const parts = [];
+        if (s.accounts) parts.push(`${s.accounts} Konten`);
+        if (s.transactions) parts.push(`${s.transactions} Transaktionen`);
+        if (s.new) parts.push(`${s.new} neu`);
+        const dur = s.duration_ms ? ` in ${(s.duration_ms / 1000).toFixed(1)}s` : "";
+        header.showToast(
+          `Aktualisiert \u2014 ${parts.join(", ") || "keine Daten"}${dur}`,
+          "success",
+        );
+      } else if (reason === "partial") {
+        const msg = `Teilweise aktualisiert \u2014 `
+          + `${s.accounts || 0} Konten, ${s.transactions || 0} Tx. `
+          + `${(s.errors || []).join(" \u00b7 ")}`.trim();
+        header.showToast(msg, "warn");
+      } else if (reason === "rate_limited") {
+        header.showToast(
+          "Tageslimit der Bank-API erreicht. Cache bleibt aktiv, "
+          + "neue Live-Daten morgen ab 00:00.",
+          "warn",
+        );
+      } else if (reason === "demo") {
+        header.showToast("Demo-Daten neu generiert.", "info");
+      } else {
+        const errs = (s.errors || []).slice(0, 2).join(" \u00b7 ")
+          || "Unbekannter Fehler";
+        header.showToast(`Aktualisierung fehlgeschlagen \u2014 ${errs}`, "error");
       }
     });
 
@@ -137,6 +180,7 @@ class FinanceDashboardPanel extends HTMLElement {
     if (header) {
       header.lastRefresh = data.lastRefresh;
       header.rateLimitedUntil = data.rateLimitedUntil;
+      header.lastRefreshStats = data.lastRefreshStats;
       if (data.demoMode !== undefined) header.demoMode = data.demoMode;
     }
 

--- a/custom_components/finance_dashboard/manager.py
+++ b/custom_components/finance_dashboard/manager.py
@@ -8,11 +8,21 @@ Coordinates between:
 
 SECURITY: All transaction data is cached in HA's .storage/ directory
 (encrypted at rest). No financial data is ever written to logs or git.
+
+CACHE vs LIVE FETCH CONTRACT:
+- ``get_cached_*`` / ``async_get_balance`` return in-memory cache only —
+  zero API calls, unbounded calls allowed. Use from HTTP read endpoints.
+- ``async_refresh_*`` hits the Enable Banking API and updates the cache —
+  ONLY called from explicit user-triggered paths (service call, refresh
+  button, setup-complete bootstrap). Enable Banking enforces a 4/day
+  ASPSP rate limit, so automatic background fetches are forbidden.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -64,6 +74,18 @@ class FinanceDashboardManager:
         self._recurring_patterns: list[dict[str, Any]] = []
         self._previous_balances: dict[str, float] = {}
         self._demo_mode: bool = False
+        # Last user-triggered refresh statistics — surfaced to the UI so
+        # the user sees exactly what happened on the last "Aktualisieren"
+        # click (accounts hit, transactions loaded, duration, outcome).
+        # Structure: {"outcome": str, "accounts": int, "transactions": int,
+        #   "new": int, "duration_ms": int, "started_at": ISO,
+        #   "finished_at": ISO, "errors": list[str]}
+        self._last_refresh_stats: dict[str, Any] = {}
+        # Serialises concurrent refresh requests (double-click guard,
+        # parallel service calls). In-flight state is also surfaced via
+        # ``is_refreshing`` so the frontend can poll for completion.
+        self._refresh_lock = asyncio.Lock()
+        self._refresh_in_flight: bool = False
 
     @property
     def rate_limited_until(self) -> datetime | None:
@@ -71,6 +93,21 @@ class FinanceDashboardManager:
         if self._rate_limited_until and datetime.now() < self._rate_limited_until:
             return self._rate_limited_until
         return None
+
+    @property
+    def is_refreshing(self) -> bool:
+        """True while a user-triggered refresh is in flight."""
+        return self._refresh_in_flight
+
+    @property
+    def last_refresh(self) -> datetime | None:
+        """Timestamp of the last successful transaction refresh, if any."""
+        return self._last_refresh
+
+    @property
+    def last_refresh_stats(self) -> dict[str, Any]:
+        """Structured stats from the most recent refresh attempt."""
+        return dict(self._last_refresh_stats)
 
     def _set_rate_limited(self) -> None:
         """Mark API as rate-limited until midnight (next calendar day)."""
@@ -105,6 +142,15 @@ class FinanceDashboardManager:
             self._balances = data["_demo_balances"]
             self._last_refresh = datetime.now()
             self._recurring_patterns = data.get("recurring", [])
+            self._last_refresh_stats = self._build_stats(
+                outcome="demo",
+                started=self._last_refresh,
+                duration_ms=0,
+                accounts=len(self._accounts),
+                transactions=len(self._transactions),
+                new=0,
+                errors=[],
+            )
             _LOGGER.info("Demo mode enabled — loaded synthetic data")
         else:
             # Clear demo data — real data reloads on next manual refresh
@@ -131,11 +177,31 @@ class FinanceDashboardManager:
             self._transactions = cached["transactions"]
             last_refresh = cached.get("last_refresh")
             if last_refresh:
-                self._last_refresh = datetime.fromisoformat(last_refresh)
+                try:
+                    self._last_refresh = datetime.fromisoformat(last_refresh)
+                except ValueError:
+                    self._last_refresh = None
+            # Cached balances survive restart so the UI shows something
+            # immediately — they're only reset by an explicit live refresh.
+            self._balances = cached.get("balances", {}) or {}
+            # Rate-limit state must survive restart — otherwise a user
+            # who hit HTTP 429 at 23:59 would "reset" by bouncing HA.
+            rl = cached.get("rate_limited_until")
+            if rl:
+                try:
+                    rl_dt = datetime.fromisoformat(rl)
+                    if rl_dt > datetime.now():
+                        self._rate_limited_until = rl_dt
+                except ValueError:
+                    pass
+            stats = cached.get("last_refresh_stats")
+            if isinstance(stats, dict):
+                self._last_refresh_stats = stats
             _LOGGER.info(
-                "Loaded %d cached transactions (last refresh: %s)",
+                "Loaded %d cached transactions (last refresh: %s, balances: %d)",
                 len(self._transactions),
                 self._last_refresh,
+                len(self._balances),
             )
 
         _LOGGER.info("Finance Manager initialized")
@@ -187,15 +253,32 @@ class FinanceDashboardManager:
     async def async_refresh_transactions(
         self, days: int = 90
     ) -> list[dict[str, Any]]:
-        """Refresh transactions for all linked accounts.
+        """Refresh transactions AND balances for all linked accounts.
 
         Fetches last N days of transactions, auto-categorizes them,
-        and persists to encrypted .storage/ cache.
+        and persists to encrypted .storage/ cache. Also refreshes
+        balances in the same user-triggered round — a single click
+        updates the entire cache.
 
         If the API returns HTTP 429 (daily quota exhausted), cached
         data is served and no further API calls are attempted until
         the next calendar day (midnight local time).
+
+        Concurrent calls are serialised by ``_refresh_lock`` and stats
+        are written to ``_last_refresh_stats`` regardless of outcome.
         """
+        async with self._refresh_lock:
+            self._refresh_in_flight = True
+            started = datetime.now()
+            t0 = time.monotonic()
+            try:
+                return await self._do_refresh(days, started, t0)
+            finally:
+                self._refresh_in_flight = False
+
+    async def _do_refresh(
+        self, days: int, started: datetime, t0: float
+    ) -> list[dict[str, Any]]:
         # Demo mode — regenerate fresh demo data without API calls
         if self._demo_mode:
             from .demo import generate_demo_data
@@ -205,6 +288,15 @@ class FinanceDashboardManager:
             self._balances = data["_demo_balances"]
             self._last_refresh = datetime.now()
             self._recurring_patterns = data.get("recurring", [])
+            self._last_refresh_stats = self._build_stats(
+                outcome="demo",
+                started=started,
+                duration_ms=int((time.monotonic() - t0) * 1000),
+                accounts=len(self._accounts),
+                transactions=len(self._transactions),
+                new=0,
+                errors=[],
+            )
             return self._transactions
 
         # Skip API calls if we're still rate-limited
@@ -213,10 +305,28 @@ class FinanceDashboardManager:
                 "API rate-limited until %s — serving cached transactions",
                 self._rate_limited_until.isoformat(),
             )
+            self._last_refresh_stats = self._build_stats(
+                outcome="rate_limited",
+                started=started,
+                duration_ms=int((time.monotonic() - t0) * 1000),
+                accounts=0,
+                transactions=len(self._transactions),
+                new=0,
+                errors=["Tageslimit der Bank-API erreicht (4/Tag pro Konto)"],
+            )
             return self._transactions
 
         client = await self._async_get_client()
         if not client:
+            self._last_refresh_stats = self._build_stats(
+                outcome="error",
+                started=started,
+                duration_ms=int((time.monotonic() - t0) * 1000),
+                accounts=0,
+                transactions=len(self._transactions),
+                new=0,
+                errors=["Keine Enable-Banking-Credentials hinterlegt"],
+            )
             return []
 
         date_from = (datetime.now() - timedelta(days=days)).strftime(
@@ -225,6 +335,8 @@ class FinanceDashboardManager:
         date_to = datetime.now().strftime("%Y-%m-%d")
 
         all_transactions = []
+        errors: list[str] = []
+        accounts_hit = 0
         for account in self._accounts:
             account_id = account.get("id")
             if not account_id:
@@ -234,6 +346,7 @@ class FinanceDashboardManager:
                 txns = await client.async_get_transactions(
                     account_id, date_from, date_to
                 )
+                accounts_hit += 1
                 booked = txns.get("booked", [])
                 pending = txns.get("pending", [])
 
@@ -269,11 +382,18 @@ class FinanceDashboardManager:
                     account_id,
                 )
                 self._set_rate_limited()
+                errors.append(
+                    f"Rate-Limit bei {account.get('name', account_id)} — "
+                    "Tageslimit (4/Tag) aufgebraucht"
+                )
                 break
-            except Exception:
+            except Exception as exc:
                 _LOGGER.exception(
                     "Failed to fetch transactions for account %s",
                     account_id,
+                )
+                errors.append(
+                    f"{account.get('name', account_id)}: {str(exc)[:120]}"
                 )
 
         # Sort by booking date (newest first)
@@ -345,23 +465,71 @@ class FinanceDashboardManager:
             len(new_txns),
             len(self._recurring_patterns),
         )
+
+        # Same user click → also refresh balances so the whole cache
+        # is consistent when the UI re-reads. Failures here are logged
+        # but do not fail the transaction refresh.
+        balance_errors: list[str] = []
+        try:
+            await self._async_refresh_balances_live(client, balance_errors)
+        except Exception:
+            _LOGGER.exception("Balance refresh leg failed")
+        errors.extend(balance_errors)
+
+        # Outcome classification: full success, partial (some accounts
+        # errored), rate_limited (quota hit during the call), or error.
+        if self.rate_limited_until:
+            outcome = "rate_limited"
+        elif errors:
+            outcome = "partial" if accounts_hit > 0 else "error"
+        else:
+            outcome = "ok"
+
+        self._last_refresh_stats = self._build_stats(
+            outcome=outcome,
+            started=started,
+            duration_ms=int((time.monotonic() - t0) * 1000),
+            accounts=accounts_hit,
+            transactions=len(all_transactions),
+            new=len(new_txns),
+            errors=errors,
+        )
+
         return all_transactions
 
-    async def async_get_balance(self) -> dict[str, Any]:
-        """Get current balances for all accounts."""
-        if self._demo_mode:
-            return self._balances
+    @staticmethod
+    def _build_stats(
+        outcome: str,
+        started: datetime,
+        duration_ms: int,
+        accounts: int,
+        transactions: int,
+        new: int,
+        errors: list[str],
+    ) -> dict[str, Any]:
+        """Assemble a refresh-stats dict for the status endpoint."""
+        finished = datetime.now()
+        return {
+            "outcome": outcome,
+            "accounts": accounts,
+            "transactions": transactions,
+            "new": new,
+            "duration_ms": duration_ms,
+            "started_at": started.isoformat(),
+            "finished_at": finished.isoformat(),
+            "errors": list(errors)[:5],  # cap payload size
+        }
 
-        # Serve cached balances while rate-limited
-        if self.rate_limited_until:
-            _LOGGER.debug("Rate-limited — serving cached balances")
-            return self._balances
+    async def _async_refresh_balances_live(
+        self, client, errors: list[str]
+    ) -> dict[str, Any]:
+        """Live-fetch balances from the API and update the cache.
 
-        client = await self._async_get_client()
-        if not client:
-            return {}
-
-        balances = {}
+        NEVER call this directly from an HTTP read endpoint — only from
+        user-triggered refresh paths.  Reads should go through
+        ``async_get_balance()`` which is cache-only.
+        """
+        balances: dict[str, Any] = {}
         for account in self._accounts:
             account_id = account.get("id")
             if not account_id:
@@ -386,18 +554,26 @@ class FinanceDashboardManager:
                 }
             except RateLimitExceeded:
                 _LOGGER.warning(
-                    "Rate limit hit fetching balance for %s — serving cache",
-                    account_id,
+                    "Rate limit hit fetching balance for %s", account_id
                 )
                 self._set_rate_limited()
+                errors.append(
+                    f"Rate-Limit beim Saldo für "
+                    f"{account.get('name', account_id)}"
+                )
+                # Serve the cache we have — no further API calls today
                 return self._balances
-            except Exception:
+            except Exception as exc:
                 _LOGGER.exception(
                     "Failed to fetch balance for account %s",
                     account_id,
                 )
+                errors.append(
+                    f"Saldo {account.get('name', account_id)}: "
+                    f"{str(exc)[:120]}"
+                )
 
-        # Fire events for significant balance changes — must not crash balance fetch
+        # Fire balance-change events — must never crash the refresh
         try:
             from .events import fire_balance_changed
 
@@ -419,8 +595,23 @@ class FinanceDashboardManager:
         except Exception:
             _LOGGER.exception("Balance change event firing failed — skipping")
 
-        self._balances = balances
-        return balances
+        if balances:
+            self._balances = balances
+        return self._balances
+
+    async def async_get_balance(self) -> dict[str, Any]:
+        """Return cached balances — NEVER hits the banking API.
+
+        This is the read path used by the HTTP balance endpoint and the
+        coordinator's state queries. Safe for unbounded reads. Live
+        updates happen inside ``async_refresh_transactions`` which is
+        only invoked from user-triggered refresh paths.
+        """
+        return dict(self._balances)
+
+    def get_cached_balances(self) -> dict[str, Any]:
+        """Synchronous alias for ``async_get_balance`` — cache only."""
+        return dict(self._balances)
 
     async def async_get_monthly_summary(
         self, month: int | None = None, year: int | None = None
@@ -545,6 +736,8 @@ class FinanceDashboardManager:
                 if self.rate_limited_until
                 else None
             ),
+            "last_refresh_stats": dict(self._last_refresh_stats),
+            "is_refreshing": self._refresh_in_flight,
         }
 
     async def async_categorize_transactions(self) -> None:
@@ -606,6 +799,38 @@ class FinanceDashboardManager:
         Full details only — caller must check admin status.
         """
         return self._transactions[:limit]
+
+    def get_refresh_status(self) -> dict[str, Any]:
+        """Return a compact status snapshot for the UI status endpoint.
+
+        Pure cache read — NEVER touches the banking API. Safe for
+        unbounded polling while a refresh is in flight.
+        """
+        now = datetime.now()
+        cache_age_seconds: int | None = None
+        if self._last_refresh:
+            cache_age_seconds = int(
+                (now - self._last_refresh).total_seconds()
+            )
+        return {
+            "is_refreshing": self._refresh_in_flight,
+            "last_refresh": (
+                self._last_refresh.isoformat()
+                if self._last_refresh
+                else None
+            ),
+            "cache_age_seconds": cache_age_seconds,
+            "rate_limited_until": (
+                self._rate_limited_until.isoformat()
+                if self.rate_limited_until
+                else None
+            ),
+            "stats": dict(self._last_refresh_stats),
+            "account_count": len(self._accounts),
+            "transaction_count": len(self._transactions),
+            "has_cache": bool(self._transactions) or bool(self._balances),
+            "demo_mode": self._demo_mode,
+        }
 
     async def _async_get_client(self):
         """Get or create Enable Banking client with current credentials."""
@@ -737,15 +962,22 @@ class FinanceDashboardManager:
         return {}
 
     async def _persist_transactions(self) -> None:
-        """Save transactions to encrypted .storage/ cache."""
+        """Save transactions, balances, rate-limit and stats to cache."""
         await self._transaction_store.async_save(
             {
                 "transactions": self._transactions,
+                "balances": self._balances,
                 "last_refresh": (
                     self._last_refresh.isoformat()
                     if self._last_refresh
                     else None
                 ),
+                "rate_limited_until": (
+                    self._rate_limited_until.isoformat()
+                    if self._rate_limited_until
+                    else None
+                ),
+                "last_refresh_stats": self._last_refresh_stats,
                 "account_count": len(self._accounts),
             }
         )

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.10.1"
+  "version": "0.11.0"
 }

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -10,6 +10,23 @@
 
 
 
+
+## 0.11.0
+- Separate cache-reads from live API fetches — `manager.async_get_balance()` now returns cached balances only (was hitting Enable Banking on every HTTP `/balances` call, burning the 4/day/ASPSP rate limit)
+- Serialise user-triggered refreshes with `asyncio.Lock` to prevent double-click concurrent fetches
+- Persist `rate_limited_until` and `last_refresh_stats` across HA restart so the 4/day counter is not lost on reboot
+- Track structured refresh stats (outcome, accounts, transactions, new, duration_ms, errors) exposed via `manager.get_refresh_status()`
+- New `POST /api/finance_dashboard/refresh` endpoint — the single user-triggered live-fetch entry point, returns stats synchronously
+- New `GET /api/finance_dashboard/refresh_status` — cache-only polling endpoint, unbounded reads allowed
+- `refresh_transactions` service now uses `SupportsResponse.OPTIONAL` and returns stats so automations can react to the outcome
+- Refresh_transactions refreshes balances in the same user-triggered round — one click, one cache update
+- Refresh button now shows a result toast ("5 Konten, 243 Transaktionen, 2 neu in 3.1s" / rate-limit / partial / error)
+- Header timestamp shows live cache age ("Zuletzt 14:23 · vor 2 Std") and updates every minute
+- Rate-limit and loading states surfaced clearly next to the refresh button instead of silent "Aktualisieren" reverts
+- "Noch keine Daten" state now has explicit styling + hint to click Aktualisieren
+- Remove staleness-based auto-refresh — coordinator is now a pure cache projection, live fetches only via dedicated endpoint
+- Docs(claude-md): replace stale GoCardless references with Enable Banking, document cache vs. live-fetch contract
+
 ## 0.10.1
 - Propagate OAuth callback errors through /setup/status so the wizard surfaces them within 2s instead of timing out after 5min
 - Hard-fail /setup/authorize when callback URL is HTTP (Enable Banking requires pre-registered HTTPS redirect)

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.10.1"
+version: "0.11.0"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -14,7 +14,7 @@ import logging
 from ha_customapps.restart import RestartNotifier
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 
 from .const import (
     DOMAIN,
@@ -140,13 +140,18 @@ async def _async_register_services(
         SERVICE_EXPORT_CSV,
     )
 
-    async def handle_refresh_accounts(call) -> None:
+    async def handle_refresh_accounts(call) -> dict:
         await manager.async_refresh_accounts()
+        return manager.get_refresh_status()
 
-    async def handle_refresh_transactions(call) -> None:
+    async def handle_refresh_transactions(call) -> dict:
+        """User-triggered refresh — returns stats so automations and
+        the frontend can surface "5 Konten, 243 Tx, 2 neu" instead
+        of a silent OK."""
         await manager.async_refresh_transactions()
         # Push fresh data to all entities via coordinator
         await coordinator.async_refresh()
+        return manager.get_refresh_status()
 
     async def handle_get_balance(call) -> dict:
         return await manager.async_get_balance()
@@ -177,10 +182,16 @@ async def _async_register_services(
         await coordinator.async_refresh()
 
     hass.services.async_register(
-        DOMAIN, SERVICE_REFRESH_ACCOUNTS, handle_refresh_accounts
+        DOMAIN,
+        SERVICE_REFRESH_ACCOUNTS,
+        handle_refresh_accounts,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_REFRESH_TRANSACTIONS, handle_refresh_transactions
+        DOMAIN,
+        SERVICE_REFRESH_TRANSACTIONS,
+        handle_refresh_transactions,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN, SERVICE_GET_BALANCE, handle_get_balance

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
@@ -34,6 +34,8 @@ async def async_register_api(hass: HomeAssistant) -> None:
     hass.http.register_view(FinanceDashboardBalanceView())
     hass.http.register_view(FinanceDashboardTransactionsView())
     hass.http.register_view(FinanceDashboardSummaryView())
+    hass.http.register_view(FinanceDashboardRefreshStatusView())
+    hass.http.register_view(FinanceDashboardRefreshTriggerView())
     # Setup wizard endpoints
     hass.http.register_view(FinanceDashboardSetupStatusView())
     hass.http.register_view(FinanceDashboardSetupInstitutionsView())
@@ -1143,3 +1145,100 @@ class FinanceDashboardSummaryView(HomeAssistantView):
 
         summary = await manager.async_get_monthly_summary()
         return self.json(summary)
+
+
+class FinanceDashboardRefreshStatusView(HomeAssistantView):
+    """Cache-only refresh status — safe for unbounded polling.
+
+    Returns the snapshot produced by ``manager.get_refresh_status()``.
+    Used by the frontend to poll while a refresh is in flight and to
+    render cache-age + last-stats in the header without ever hitting
+    the banking API.
+    """
+
+    url = f"/api/{DOMAIN}/refresh_status"
+    name = f"api:{DOMAIN}:refresh_status"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return the current refresh snapshot (no API calls)."""
+        hass = request.app["hass"]
+        manager = _get_manager(hass)
+
+        if not manager:
+            return self.json(
+                {
+                    "is_refreshing": False,
+                    "has_cache": False,
+                    "error": "Not configured",
+                }
+            )
+
+        return self.json(manager.get_refresh_status())
+
+
+class FinanceDashboardRefreshTriggerView(HomeAssistantView):
+    """Explicit user-triggered refresh — the ONLY allowed live-fetch entry.
+
+    Blocks while the refresh is in flight and returns the final stats,
+    so the frontend can show a single "5 Konten, 243 Transaktionen"
+    toast instead of polling guesswork. Hard Rule: only invoked on
+    user-initiated actions (refresh button, manual service call).
+    """
+
+    url = f"/api/{DOMAIN}/refresh"
+    name = f"api:{DOMAIN}:refresh"
+    requires_auth = True
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Run a refresh and return the stats when it finishes."""
+        hass = request.app["hass"]
+        manager = _get_manager(hass)
+
+        if not manager:
+            return self.json(
+                {"error": "Not configured"}, status_code=404
+            )
+
+        # Short-circuit when already rate-limited so the UI can show a
+        # clear message instead of waiting for an HTTP 429 round-trip.
+        if manager.rate_limited_until:
+            return self.json(
+                {
+                    "ok": False,
+                    "reason": "rate_limited",
+                    "status": manager.get_refresh_status(),
+                }
+            )
+
+        try:
+            await manager.async_refresh_transactions()
+        except Exception as exc:
+            _LOGGER.exception("Refresh trigger failed")
+            return self.json(
+                {
+                    "ok": False,
+                    "reason": "error",
+                    "message": str(exc)[:200],
+                    "status": manager.get_refresh_status(),
+                }
+            )
+
+        # Also push fresh data through the coordinator so entity states
+        # update in lockstep with the user's click.
+        domain_data = hass.data.get(DOMAIN, {})
+        entry = domain_data.get("entry")
+        if entry:
+            coordinator = domain_data.get(
+                f"{entry.entry_id}_coordinator"
+            )
+            if coordinator:
+                try:
+                    await coordinator.async_refresh()
+                except Exception:
+                    _LOGGER.exception(
+                        "Coordinator refresh after live fetch failed"
+                    )
+
+        status = manager.get_refresh_status()
+        return self.json({"ok": True, "status": status})

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.10.1"
+VERSION = "0.11.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
@@ -73,14 +73,13 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
 
         This method is ONLY reached when the user explicitly triggers
         a refresh (UI button or service call). It never runs automatically.
+
+        Cache-read only: balances and summary are read from the manager's
+        in-memory cache — no live API calls. Live fetches happen inside
+        ``manager.async_refresh_transactions`` (which also refreshes
+        balances) and are gated by an explicit user trigger.
         """
         try:
-            # Refresh raw transactions only when the cache is stale.
-            last = self._manager._last_refresh
-            if last is None or (datetime.now() - last) > TRANSACTION_REFRESH_STALENESS:
-                _LOGGER.debug("Transaction cache stale — refreshing from API")
-                await self._manager.async_refresh_transactions()
-
             balances = await self._manager.async_get_balance()
             summary = await self._manager.async_get_monthly_summary()
 
@@ -88,7 +87,10 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
             return {
                 "balances": balances,
                 "summary": summary,
-                "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
+                "rate_limited_until": (
+                    rate_limited.isoformat() if rate_limited else None
+                ),
+                "refresh_status": self._manager.get_refresh_status(),
             }
         except Exception as exc:
             raise UpdateFailed(f"Finance data update failed: {exc}") from exc

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -190,23 +190,78 @@ class FdDataProvider extends HTMLElement {
     }
   }
 
-  /** Trigger a full data rebuild (manual refresh). */
+  /** Trigger a full data rebuild (manual refresh).
+   *
+   *  Returns a stats object the panel can surface in a toast:
+   *    { outcome, accounts, transactions, new, duration_ms, errors,
+   *      rate_limited_until, last_refresh, cache_age_seconds }
+   *
+   *  "outcome" is one of: ok | partial | rate_limited | error | demo.
+   */
   async refresh() {
-    if (!this._hass) return;
+    if (!this._hass) return { outcome: "error", errors: ["no hass"] };
     if (this._demoMode) {
-      // In demo mode, just regenerate demo data
       await this._loadDemoData();
-      return;
+      return { outcome: "demo" };
     }
-    // Ask HA to refresh transactions, which triggers coordinator update
+    // Notify listeners that a live fetch started — used by the header
+    // to show the spinner chip instead of the static timestamp.
+    this.dispatchEvent(new CustomEvent("fd-refresh-started", {
+      bubbles: true,
+      composed: true,
+    }));
+
+    let resultStatus = null;
     try {
-      await this._hass.callService(DOMAIN, "refresh_transactions");
+      // Dedicated endpoint blocks until the refresh completes and
+      // returns structured stats. Using this instead of the HA service
+      // call avoids the pre-2024 no-response behaviour on older cores.
+      const resp = await this._hass.callApi("POST", `${DOMAIN}/refresh`);
+      resultStatus = resp?.status || null;
+      if (resp && resp.ok === false) {
+        // Rate-limited or hard error — still dispatch the status so the
+        // header can render the "Morgen verfügbar" chip correctly.
+        this.dispatchEvent(new CustomEvent("fd-refresh-done", {
+          detail: {
+            status: resultStatus,
+            ok: false,
+            reason: resp.reason,
+          },
+          bubbles: true,
+          composed: true,
+        }));
+      }
     } catch (e) {
-      console.warn("fd-data-provider: refresh_transactions failed:", e);
+      console.warn("fd-data-provider: /refresh endpoint failed:", e);
     }
+
     // Force immediate rebuild — allow API fallback for household/recurring
     this._prevStateHash = "";
     await this._rebuild(true);
+
+    if (resultStatus && resultStatus.stats) {
+      this.dispatchEvent(new CustomEvent("fd-refresh-done", {
+        detail: {
+          status: resultStatus,
+          ok: resultStatus.stats.outcome === "ok",
+          reason: resultStatus.stats.outcome,
+        },
+        bubbles: true,
+        composed: true,
+      }));
+    }
+    return resultStatus || {};
+  }
+
+  /** Fetch the current refresh status (cache-only, unbounded-safe). */
+  async fetchRefreshStatus() {
+    if (!this._hass) return null;
+    try {
+      return await this._hass.callApi("GET", `${DOMAIN}/refresh_status`);
+    } catch (e) {
+      console.warn("fd-data-provider: /refresh_status failed:", e);
+      return null;
+    }
   }
 
   /** Check if relevant entity states changed and rebuild if needed. */
@@ -267,6 +322,8 @@ class FdDataProvider extends HTMLElement {
         error: null,
         lastRefresh: null,
         rateLimitedUntil: null,
+        lastRefreshStats: null,
+        isRefreshing: false,
       };
 
       // 1. Read entities using registry-based lookup
@@ -346,6 +403,8 @@ class FdDataProvider extends HTMLElement {
           data.summary.year = sa.year || data.summary.year;
           data.lastRefresh = sa.last_refresh || null;
           data.rateLimitedUntil = sa.rate_limited_until || null;
+          data.lastRefreshStats = sa.last_refresh_stats || null;
+          data.isRefreshing = !!sa.is_refreshing;
 
           // Household and recurring from entity attrs (added in v0.7.9+)
           if (sa.household) data.household = sa.household;

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
@@ -1,8 +1,12 @@
 /**
- * fd-header — Title bar with month selector, refresh button, and status chip.
+ * fd-header — Title bar with month selector, refresh button, status chip, toast.
  *
  * Properties:
- *   lastRefresh {string} — ISO timestamp of last data update
+ *   lastRefresh       {string} — ISO timestamp of last successful refresh
+ *   refreshing        {bool}   — live fetch in flight
+ *   rateLimitedUntil  {string} — ISO timestamp; if future, refresh is blocked
+ *   lastRefreshStats  {object} — {outcome, accounts, transactions, new, duration_ms, errors}
+ *   demoMode          {bool}
  *
  * Events dispatched:
  *   fd-refresh-requested — User clicked refresh button
@@ -16,21 +20,32 @@ class FdHeader extends HTMLElement {
     this._refreshing = false;
     this._rateLimitedUntil = null;
     this._demoMode = false;
+    this._lastRefreshStats = null;
+    this._timestampTimer = null;
+    this._toastTimer = null;
   }
 
   set lastRefresh(v) {
     this._lastRefresh = v;
     this._updateTimestamp();
+    this._scheduleTimestampTick();
   }
 
   set refreshing(v) {
     this._refreshing = v;
     this._updateRefreshBtn();
+    this._updateTimestamp();
   }
 
   set rateLimitedUntil(v) {
     this._rateLimitedUntil = v;
     this._updateRefreshBtn();
+    this._updateTimestamp();
+  }
+
+  set lastRefreshStats(v) {
+    this._lastRefreshStats = v;
+    this._updateTimestamp();
   }
 
   set demoMode(v) {
@@ -44,20 +59,44 @@ class FdHeader extends HTMLElement {
     if (this._rateLimitedUntil && new Date(this._rateLimitedUntil) > new Date()) {
       btn.disabled = true;
       btn.textContent = "Morgen verf\u00fcgbar";
-      btn.title = "Tageslimit der Bank-API erreicht. N\u00e4chste Aktualisierung ab morgen.";
+      btn.title = "Tageslimit der Bank-API erreicht (4/Tag pro Konto). N\u00e4chste Aktualisierung ab morgen.";
     } else if (this._refreshing) {
       btn.disabled = true;
-      btn.textContent = "Laden\u2026";
-      btn.title = "";
+      btn.textContent = "L\u00e4dt\u2026";
+      btn.title = "Bank-API wird abgefragt\u2014dies kann einige Sekunden dauern.";
     } else {
       btn.disabled = false;
       btn.textContent = "Aktualisieren";
-      btn.title = "";
+      btn.title = "Live-Daten von der Bank-API holen";
     }
   }
 
   connectedCallback() {
     this._render();
+  }
+
+  disconnectedCallback() {
+    if (this._timestampTimer) clearInterval(this._timestampTimer);
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+  }
+
+  _scheduleTimestampTick() {
+    // Once we have a timestamp, update the "vor N min" label every 60s
+    // so the user always sees the current cache age without reloading.
+    if (this._timestampTimer || !this._lastRefresh) return;
+    this._timestampTimer = setInterval(() => this._updateTimestamp(), 60000);
+  }
+
+  /** Public: show a toast with refresh results. */
+  showToast(message, kind) {
+    const toast = this.shadowRoot.getElementById("toast");
+    if (!toast) return;
+    toast.textContent = message;
+    toast.className = `toast toast-${kind || "info"} show`;
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+    this._toastTimer = setTimeout(() => {
+      toast.classList.remove("show");
+    }, kind === "error" ? 7000 : 4500);
   }
 
   _updateDemoBtn() {
@@ -166,6 +205,49 @@ h1 {
 .btn-demo-active:hover {
   background: #e67e22;
 }
+.ts-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  line-height: 1.2;
+}
+.ts-stats {
+  font-size: 10px;
+  color: var(--tx2);
+  opacity: 0.85;
+}
+.ts.loading { color: var(--ac); }
+.ts.empty   { color: var(--tx2); font-style: italic; }
+.ts.rate    { color: var(--demo); }
+
+/* Toast */
+.toast {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 2000;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  background: var(--sf);
+  color: var(--tx);
+  border: 1px solid var(--bd);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.25s, transform 0.25s;
+  max-width: 360px;
+  white-space: pre-wrap;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+.toast-success { border-color: var(--ac); }
+.toast-info    { border-color: rgba(78,204,163,0.3); }
+.toast-warn    { border-color: var(--demo); color: var(--demo); }
+.toast-error   { border-color: #e74c3c; color: #e74c3c; }
+
 @media (max-width: 600px) {
   .hdr { flex-wrap: wrap; gap: 10px; }
   .right { width: 100%; justify-content: flex-end; }
@@ -173,13 +255,17 @@ h1 {
   .btn { padding: 6px 10px; font-size: 12px; }
 }
 </style>
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
 <div class="hdr">
   <div class="title-row">
     <h1>Finance Dashboard</h1>
     <span class="demo-badge" id="demoBadge">DEMO</span>
   </div>
   <div class="right">
-    <span class="ts" id="ts">Noch keine Daten</span>
+    <div class="ts-stack">
+      <span class="ts empty" id="ts">Noch keine Daten \u2014 klicke "Aktualisieren"</span>
+      <span class="ts-stats" id="tsStats"></span>
+    </div>
     <button class="btn btn-demo" id="demoBtn" aria-label="Demo-Modus umschalten" aria-pressed="false">Demo</button>
     <button class="btn" id="monthBtn">${monthLabel}</button>
     <button class="btn btn-p" id="refreshBtn">Aktualisieren</button>
@@ -217,11 +303,73 @@ h1 {
 
   _updateTimestamp() {
     const el = this.shadowRoot.getElementById("ts");
+    const statsEl = this.shadowRoot.getElementById("tsStats");
     if (!el) return;
+
+    // Refresh in flight takes priority over everything else.
+    if (this._refreshing) {
+      el.className = "ts loading";
+      el.textContent = "Aktualisiere\u2026 Bank-API wird abgefragt";
+      if (statsEl) statsEl.textContent = "";
+      return;
+    }
+
+    // Hard rate-limit state — surface it where the user looks first.
+    if (this._rateLimitedUntil && new Date(this._rateLimitedUntil) > new Date()) {
+      el.className = "ts rate";
+      el.textContent = "Tageslimit erreicht \u2014 Cache wird genutzt";
+      if (statsEl) {
+        const next = new Date(this._rateLimitedUntil);
+        statsEl.textContent = `Neue Abfragen ab ${next.toLocaleDateString("de-DE")} 00:00`;
+      }
+      return;
+    }
+
     if (this._lastRefresh) {
       const d = new Date(this._lastRefresh);
-      el.textContent = `Zuletzt: ${d.toLocaleTimeString("de-DE")}`;
+      const timeStr = d.toLocaleTimeString("de-DE", {
+        hour: "2-digit", minute: "2-digit",
+      });
+      const dayStr = d.toLocaleDateString("de-DE", {
+        day: "2-digit", month: "2-digit",
+      });
+      const ageMin = Math.max(0, Math.round((Date.now() - d.getTime()) / 60000));
+      let ageLabel;
+      if (ageMin < 1) ageLabel = "gerade eben";
+      else if (ageMin < 60) ageLabel = `vor ${ageMin} Min`;
+      else if (ageMin < 1440) {
+        const h = Math.round(ageMin / 60);
+        ageLabel = `vor ${h} Std`;
+      } else {
+        const days = Math.round(ageMin / 1440);
+        ageLabel = `vor ${days} Tg`;
+      }
+      el.className = "ts";
+      el.textContent = `Zuletzt: ${timeStr} (${ageLabel})`;
+      el.title = `Letzte Aktualisierung: ${dayStr} ${timeStr}`;
+
+      if (statsEl) {
+        const s = this._lastRefreshStats;
+        if (s && s.outcome) {
+          const parts = [];
+          if (s.accounts != null) parts.push(`${s.accounts} Konten`);
+          if (s.transactions != null) parts.push(`${s.transactions} Tx`);
+          if (s.new) parts.push(`${s.new} neu`);
+          if (s.outcome === "partial") parts.push("teilweise Fehler");
+          else if (s.outcome === "rate_limited") parts.push("Rate-Limit");
+          else if (s.outcome === "error") parts.push("Fehler");
+          statsEl.textContent = parts.join(" \u00b7 ");
+        } else {
+          statsEl.textContent = "";
+        }
+      }
+      return;
     }
+
+    // No cache at all.
+    el.className = "ts empty";
+    el.textContent = "Noch keine Daten \u2014 klicke \"Aktualisieren\"";
+    if (statsEl) statsEl.textContent = "";
   }
 }
 

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -84,6 +84,13 @@ class FinanceDashboardPanel extends HTMLElement {
       // but guard here as well.
       if (header && header._rateLimitedUntil &&
           new Date(header._rateLimitedUntil) > new Date()) {
+        if (header.showToast) {
+          header.showToast(
+            "Tageslimit der Bank-API ist erreicht (4/Tag pro Konto). "
+            + "Neue Abfragen sind erst ab morgen 00:00 m\u00f6glich.",
+            "warn",
+          );
+        }
         return;
       }
       if (header) header.refreshing = true;
@@ -91,6 +98,42 @@ class FinanceDashboardPanel extends HTMLElement {
         dp.refresh().finally(() => {
           if (header) header.refreshing = false;
         });
+      }
+    });
+
+    this.shadowRoot.addEventListener("fd-refresh-done", (e) => {
+      const header = this.shadowRoot.querySelector("fd-header");
+      if (!header || !header.showToast) return;
+      const d = e.detail || {};
+      const s = d.status?.stats || {};
+      const reason = d.reason || s.outcome || "error";
+      if (reason === "ok") {
+        const parts = [];
+        if (s.accounts) parts.push(`${s.accounts} Konten`);
+        if (s.transactions) parts.push(`${s.transactions} Transaktionen`);
+        if (s.new) parts.push(`${s.new} neu`);
+        const dur = s.duration_ms ? ` in ${(s.duration_ms / 1000).toFixed(1)}s` : "";
+        header.showToast(
+          `Aktualisiert \u2014 ${parts.join(", ") || "keine Daten"}${dur}`,
+          "success",
+        );
+      } else if (reason === "partial") {
+        const msg = `Teilweise aktualisiert \u2014 `
+          + `${s.accounts || 0} Konten, ${s.transactions || 0} Tx. `
+          + `${(s.errors || []).join(" \u00b7 ")}`.trim();
+        header.showToast(msg, "warn");
+      } else if (reason === "rate_limited") {
+        header.showToast(
+          "Tageslimit der Bank-API erreicht. Cache bleibt aktiv, "
+          + "neue Live-Daten morgen ab 00:00.",
+          "warn",
+        );
+      } else if (reason === "demo") {
+        header.showToast("Demo-Daten neu generiert.", "info");
+      } else {
+        const errs = (s.errors || []).slice(0, 2).join(" \u00b7 ")
+          || "Unbekannter Fehler";
+        header.showToast(`Aktualisierung fehlgeschlagen \u2014 ${errs}`, "error");
       }
     });
 
@@ -137,6 +180,7 @@ class FinanceDashboardPanel extends HTMLElement {
     if (header) {
       header.lastRefresh = data.lastRefresh;
       header.rateLimitedUntil = data.rateLimitedUntil;
+      header.lastRefreshStats = data.lastRefreshStats;
       if (data.demoMode !== undefined) header.demoMode = data.demoMode;
     }
 

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
@@ -8,11 +8,21 @@ Coordinates between:
 
 SECURITY: All transaction data is cached in HA's .storage/ directory
 (encrypted at rest). No financial data is ever written to logs or git.
+
+CACHE vs LIVE FETCH CONTRACT:
+- ``get_cached_*`` / ``async_get_balance`` return in-memory cache only —
+  zero API calls, unbounded calls allowed. Use from HTTP read endpoints.
+- ``async_refresh_*`` hits the Enable Banking API and updates the cache —
+  ONLY called from explicit user-triggered paths (service call, refresh
+  button, setup-complete bootstrap). Enable Banking enforces a 4/day
+  ASPSP rate limit, so automatic background fetches are forbidden.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -64,6 +74,18 @@ class FinanceDashboardManager:
         self._recurring_patterns: list[dict[str, Any]] = []
         self._previous_balances: dict[str, float] = {}
         self._demo_mode: bool = False
+        # Last user-triggered refresh statistics — surfaced to the UI so
+        # the user sees exactly what happened on the last "Aktualisieren"
+        # click (accounts hit, transactions loaded, duration, outcome).
+        # Structure: {"outcome": str, "accounts": int, "transactions": int,
+        #   "new": int, "duration_ms": int, "started_at": ISO,
+        #   "finished_at": ISO, "errors": list[str]}
+        self._last_refresh_stats: dict[str, Any] = {}
+        # Serialises concurrent refresh requests (double-click guard,
+        # parallel service calls). In-flight state is also surfaced via
+        # ``is_refreshing`` so the frontend can poll for completion.
+        self._refresh_lock = asyncio.Lock()
+        self._refresh_in_flight: bool = False
 
     @property
     def rate_limited_until(self) -> datetime | None:
@@ -71,6 +93,21 @@ class FinanceDashboardManager:
         if self._rate_limited_until and datetime.now() < self._rate_limited_until:
             return self._rate_limited_until
         return None
+
+    @property
+    def is_refreshing(self) -> bool:
+        """True while a user-triggered refresh is in flight."""
+        return self._refresh_in_flight
+
+    @property
+    def last_refresh(self) -> datetime | None:
+        """Timestamp of the last successful transaction refresh, if any."""
+        return self._last_refresh
+
+    @property
+    def last_refresh_stats(self) -> dict[str, Any]:
+        """Structured stats from the most recent refresh attempt."""
+        return dict(self._last_refresh_stats)
 
     def _set_rate_limited(self) -> None:
         """Mark API as rate-limited until midnight (next calendar day)."""
@@ -105,6 +142,15 @@ class FinanceDashboardManager:
             self._balances = data["_demo_balances"]
             self._last_refresh = datetime.now()
             self._recurring_patterns = data.get("recurring", [])
+            self._last_refresh_stats = self._build_stats(
+                outcome="demo",
+                started=self._last_refresh,
+                duration_ms=0,
+                accounts=len(self._accounts),
+                transactions=len(self._transactions),
+                new=0,
+                errors=[],
+            )
             _LOGGER.info("Demo mode enabled — loaded synthetic data")
         else:
             # Clear demo data — real data reloads on next manual refresh
@@ -131,11 +177,31 @@ class FinanceDashboardManager:
             self._transactions = cached["transactions"]
             last_refresh = cached.get("last_refresh")
             if last_refresh:
-                self._last_refresh = datetime.fromisoformat(last_refresh)
+                try:
+                    self._last_refresh = datetime.fromisoformat(last_refresh)
+                except ValueError:
+                    self._last_refresh = None
+            # Cached balances survive restart so the UI shows something
+            # immediately — they're only reset by an explicit live refresh.
+            self._balances = cached.get("balances", {}) or {}
+            # Rate-limit state must survive restart — otherwise a user
+            # who hit HTTP 429 at 23:59 would "reset" by bouncing HA.
+            rl = cached.get("rate_limited_until")
+            if rl:
+                try:
+                    rl_dt = datetime.fromisoformat(rl)
+                    if rl_dt > datetime.now():
+                        self._rate_limited_until = rl_dt
+                except ValueError:
+                    pass
+            stats = cached.get("last_refresh_stats")
+            if isinstance(stats, dict):
+                self._last_refresh_stats = stats
             _LOGGER.info(
-                "Loaded %d cached transactions (last refresh: %s)",
+                "Loaded %d cached transactions (last refresh: %s, balances: %d)",
                 len(self._transactions),
                 self._last_refresh,
+                len(self._balances),
             )
 
         _LOGGER.info("Finance Manager initialized")
@@ -187,15 +253,32 @@ class FinanceDashboardManager:
     async def async_refresh_transactions(
         self, days: int = 90
     ) -> list[dict[str, Any]]:
-        """Refresh transactions for all linked accounts.
+        """Refresh transactions AND balances for all linked accounts.
 
         Fetches last N days of transactions, auto-categorizes them,
-        and persists to encrypted .storage/ cache.
+        and persists to encrypted .storage/ cache. Also refreshes
+        balances in the same user-triggered round — a single click
+        updates the entire cache.
 
         If the API returns HTTP 429 (daily quota exhausted), cached
         data is served and no further API calls are attempted until
         the next calendar day (midnight local time).
+
+        Concurrent calls are serialised by ``_refresh_lock`` and stats
+        are written to ``_last_refresh_stats`` regardless of outcome.
         """
+        async with self._refresh_lock:
+            self._refresh_in_flight = True
+            started = datetime.now()
+            t0 = time.monotonic()
+            try:
+                return await self._do_refresh(days, started, t0)
+            finally:
+                self._refresh_in_flight = False
+
+    async def _do_refresh(
+        self, days: int, started: datetime, t0: float
+    ) -> list[dict[str, Any]]:
         # Demo mode — regenerate fresh demo data without API calls
         if self._demo_mode:
             from .demo import generate_demo_data
@@ -205,6 +288,15 @@ class FinanceDashboardManager:
             self._balances = data["_demo_balances"]
             self._last_refresh = datetime.now()
             self._recurring_patterns = data.get("recurring", [])
+            self._last_refresh_stats = self._build_stats(
+                outcome="demo",
+                started=started,
+                duration_ms=int((time.monotonic() - t0) * 1000),
+                accounts=len(self._accounts),
+                transactions=len(self._transactions),
+                new=0,
+                errors=[],
+            )
             return self._transactions
 
         # Skip API calls if we're still rate-limited
@@ -213,10 +305,28 @@ class FinanceDashboardManager:
                 "API rate-limited until %s — serving cached transactions",
                 self._rate_limited_until.isoformat(),
             )
+            self._last_refresh_stats = self._build_stats(
+                outcome="rate_limited",
+                started=started,
+                duration_ms=int((time.monotonic() - t0) * 1000),
+                accounts=0,
+                transactions=len(self._transactions),
+                new=0,
+                errors=["Tageslimit der Bank-API erreicht (4/Tag pro Konto)"],
+            )
             return self._transactions
 
         client = await self._async_get_client()
         if not client:
+            self._last_refresh_stats = self._build_stats(
+                outcome="error",
+                started=started,
+                duration_ms=int((time.monotonic() - t0) * 1000),
+                accounts=0,
+                transactions=len(self._transactions),
+                new=0,
+                errors=["Keine Enable-Banking-Credentials hinterlegt"],
+            )
             return []
 
         date_from = (datetime.now() - timedelta(days=days)).strftime(
@@ -225,6 +335,8 @@ class FinanceDashboardManager:
         date_to = datetime.now().strftime("%Y-%m-%d")
 
         all_transactions = []
+        errors: list[str] = []
+        accounts_hit = 0
         for account in self._accounts:
             account_id = account.get("id")
             if not account_id:
@@ -234,6 +346,7 @@ class FinanceDashboardManager:
                 txns = await client.async_get_transactions(
                     account_id, date_from, date_to
                 )
+                accounts_hit += 1
                 booked = txns.get("booked", [])
                 pending = txns.get("pending", [])
 
@@ -269,11 +382,18 @@ class FinanceDashboardManager:
                     account_id,
                 )
                 self._set_rate_limited()
+                errors.append(
+                    f"Rate-Limit bei {account.get('name', account_id)} — "
+                    "Tageslimit (4/Tag) aufgebraucht"
+                )
                 break
-            except Exception:
+            except Exception as exc:
                 _LOGGER.exception(
                     "Failed to fetch transactions for account %s",
                     account_id,
+                )
+                errors.append(
+                    f"{account.get('name', account_id)}: {str(exc)[:120]}"
                 )
 
         # Sort by booking date (newest first)
@@ -345,23 +465,71 @@ class FinanceDashboardManager:
             len(new_txns),
             len(self._recurring_patterns),
         )
+
+        # Same user click → also refresh balances so the whole cache
+        # is consistent when the UI re-reads. Failures here are logged
+        # but do not fail the transaction refresh.
+        balance_errors: list[str] = []
+        try:
+            await self._async_refresh_balances_live(client, balance_errors)
+        except Exception:
+            _LOGGER.exception("Balance refresh leg failed")
+        errors.extend(balance_errors)
+
+        # Outcome classification: full success, partial (some accounts
+        # errored), rate_limited (quota hit during the call), or error.
+        if self.rate_limited_until:
+            outcome = "rate_limited"
+        elif errors:
+            outcome = "partial" if accounts_hit > 0 else "error"
+        else:
+            outcome = "ok"
+
+        self._last_refresh_stats = self._build_stats(
+            outcome=outcome,
+            started=started,
+            duration_ms=int((time.monotonic() - t0) * 1000),
+            accounts=accounts_hit,
+            transactions=len(all_transactions),
+            new=len(new_txns),
+            errors=errors,
+        )
+
         return all_transactions
 
-    async def async_get_balance(self) -> dict[str, Any]:
-        """Get current balances for all accounts."""
-        if self._demo_mode:
-            return self._balances
+    @staticmethod
+    def _build_stats(
+        outcome: str,
+        started: datetime,
+        duration_ms: int,
+        accounts: int,
+        transactions: int,
+        new: int,
+        errors: list[str],
+    ) -> dict[str, Any]:
+        """Assemble a refresh-stats dict for the status endpoint."""
+        finished = datetime.now()
+        return {
+            "outcome": outcome,
+            "accounts": accounts,
+            "transactions": transactions,
+            "new": new,
+            "duration_ms": duration_ms,
+            "started_at": started.isoformat(),
+            "finished_at": finished.isoformat(),
+            "errors": list(errors)[:5],  # cap payload size
+        }
 
-        # Serve cached balances while rate-limited
-        if self.rate_limited_until:
-            _LOGGER.debug("Rate-limited — serving cached balances")
-            return self._balances
+    async def _async_refresh_balances_live(
+        self, client, errors: list[str]
+    ) -> dict[str, Any]:
+        """Live-fetch balances from the API and update the cache.
 
-        client = await self._async_get_client()
-        if not client:
-            return {}
-
-        balances = {}
+        NEVER call this directly from an HTTP read endpoint — only from
+        user-triggered refresh paths.  Reads should go through
+        ``async_get_balance()`` which is cache-only.
+        """
+        balances: dict[str, Any] = {}
         for account in self._accounts:
             account_id = account.get("id")
             if not account_id:
@@ -386,18 +554,26 @@ class FinanceDashboardManager:
                 }
             except RateLimitExceeded:
                 _LOGGER.warning(
-                    "Rate limit hit fetching balance for %s — serving cache",
-                    account_id,
+                    "Rate limit hit fetching balance for %s", account_id
                 )
                 self._set_rate_limited()
+                errors.append(
+                    f"Rate-Limit beim Saldo für "
+                    f"{account.get('name', account_id)}"
+                )
+                # Serve the cache we have — no further API calls today
                 return self._balances
-            except Exception:
+            except Exception as exc:
                 _LOGGER.exception(
                     "Failed to fetch balance for account %s",
                     account_id,
                 )
+                errors.append(
+                    f"Saldo {account.get('name', account_id)}: "
+                    f"{str(exc)[:120]}"
+                )
 
-        # Fire events for significant balance changes — must not crash balance fetch
+        # Fire balance-change events — must never crash the refresh
         try:
             from .events import fire_balance_changed
 
@@ -419,8 +595,23 @@ class FinanceDashboardManager:
         except Exception:
             _LOGGER.exception("Balance change event firing failed — skipping")
 
-        self._balances = balances
-        return balances
+        if balances:
+            self._balances = balances
+        return self._balances
+
+    async def async_get_balance(self) -> dict[str, Any]:
+        """Return cached balances — NEVER hits the banking API.
+
+        This is the read path used by the HTTP balance endpoint and the
+        coordinator's state queries. Safe for unbounded reads. Live
+        updates happen inside ``async_refresh_transactions`` which is
+        only invoked from user-triggered refresh paths.
+        """
+        return dict(self._balances)
+
+    def get_cached_balances(self) -> dict[str, Any]:
+        """Synchronous alias for ``async_get_balance`` — cache only."""
+        return dict(self._balances)
 
     async def async_get_monthly_summary(
         self, month: int | None = None, year: int | None = None
@@ -545,6 +736,8 @@ class FinanceDashboardManager:
                 if self.rate_limited_until
                 else None
             ),
+            "last_refresh_stats": dict(self._last_refresh_stats),
+            "is_refreshing": self._refresh_in_flight,
         }
 
     async def async_categorize_transactions(self) -> None:
@@ -606,6 +799,38 @@ class FinanceDashboardManager:
         Full details only — caller must check admin status.
         """
         return self._transactions[:limit]
+
+    def get_refresh_status(self) -> dict[str, Any]:
+        """Return a compact status snapshot for the UI status endpoint.
+
+        Pure cache read — NEVER touches the banking API. Safe for
+        unbounded polling while a refresh is in flight.
+        """
+        now = datetime.now()
+        cache_age_seconds: int | None = None
+        if self._last_refresh:
+            cache_age_seconds = int(
+                (now - self._last_refresh).total_seconds()
+            )
+        return {
+            "is_refreshing": self._refresh_in_flight,
+            "last_refresh": (
+                self._last_refresh.isoformat()
+                if self._last_refresh
+                else None
+            ),
+            "cache_age_seconds": cache_age_seconds,
+            "rate_limited_until": (
+                self._rate_limited_until.isoformat()
+                if self.rate_limited_until
+                else None
+            ),
+            "stats": dict(self._last_refresh_stats),
+            "account_count": len(self._accounts),
+            "transaction_count": len(self._transactions),
+            "has_cache": bool(self._transactions) or bool(self._balances),
+            "demo_mode": self._demo_mode,
+        }
 
     async def _async_get_client(self):
         """Get or create Enable Banking client with current credentials."""
@@ -737,15 +962,22 @@ class FinanceDashboardManager:
         return {}
 
     async def _persist_transactions(self) -> None:
-        """Save transactions to encrypted .storage/ cache."""
+        """Save transactions, balances, rate-limit and stats to cache."""
         await self._transaction_store.async_save(
             {
                 "transactions": self._transactions,
+                "balances": self._balances,
                 "last_refresh": (
                     self._last_refresh.isoformat()
                     if self._last_refresh
                     else None
                 ),
+                "rate_limited_until": (
+                    self._rate_limited_until.isoformat()
+                    if self._rate_limited_until
+                    else None
+                ),
+                "last_refresh_stats": self._last_refresh_stats,
                 "account_count": len(self._accounts),
             }
         )

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.10.1"
+  "version": "0.11.0"
 }


### PR DESCRIPTION
## Summary

Fixes the refresh flow end-to-end. Users now see concrete feedback ("5 Konten, 243 Transaktionen, 2 neu in 3.1s"), cache-reads are unbounded, and live Enable-Banking calls happen only on explicit user action to respect the 4/day ASPSP rate limit.

## Root cause
- `manager.async_get_balance()` hit the bank API on every `/balances` call — every panel poll burned rate limit.
- Refresh button gave no outcome feedback; rate-limit and partial-fail states were silent.
- `_rate_limited_until` was memory-only and lost on HA restart.
- No status endpoint for the frontend to track in-flight refreshes.

## Changes
- **core**: `async_get_balance()` cache-only; new async lock-guarded refresh round that fetches transactions + balances together; persist `rate_limited_until` + `last_refresh_stats` across restart; new `manager.get_refresh_status()`.
- **api**: `POST /api/finance_dashboard/refresh` (single live-fetch entry) + `GET /api/finance_dashboard/refresh_status` (cache-only polling) + service returns stats via `SupportsResponse.OPTIONAL`.
- **frontend**: result toast with counts + duration, rate-limit and partial variants; header shows live cache age ("Zuletzt 14:23 · vor 2 Std"); explicit "Noch keine Daten" state with CTA.
- **docs**: CLAUDE.md — GoCardless references replaced with Enable Banking; cache vs. live-fetch contract documented.

## Verification
- `python -m py_compile` on all touched backend files (src + addon payload): PASS
- `node --check` on all touched frontend files (src + addon payload): PASS
- `bump_versions.py --part minor` → 0.10.1 → 0.11.0, payload synced
- `sync_changelog.py --version 0.11.0` → CHANGELOG.md + addon CHANGELOG.md synced

Closes the "refresh zeigt nie ob Daten gezogen wurden" workflow issue.