### PR TITLE
fix(frontend): demo chip, refresh race, rebuild deadlock (v0.11.1)

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,14 @@
 # Build Log
 
+## 0.11.1 — 2026-04-20
+Version: 0.11.1
+Branch: claude/fix-refresh-demo-race-0-11-1
+PR: (pending)
+Changes:
+- fix(frontend): btn-demo now renders neutral/ghost by default — orange fill only when demo mode is active (btn-demo-active), preventing false "already in demo" appearance
+- fix(frontend): refresh race eliminated — after POST /refresh, poll for entity state change (≤5s, 500ms ticks) before calling _rebuild(), avoiding stale hass.states read that returned accountCount=0 and flashed onboarding screen
+- fix(frontend): _onHassChanged no longer advances _prevStateHash when _loading=true; instead sets _pendingRebuild=true so _rebuild retries immediately after the in-flight rebuild finishes, closing the concurrent-rebuild deadlock
+
 ## 0.11.0 — 2026-04-20
 Version: 0.11.0
 Branch: claude/bold-swirles-d0afe6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,13 @@ All notable changes to the Finance will be documented in this file.
 - Separate cache-reads from live API fetches — `manager.async_get_balance()` now returns cached balances only (was hitting Enable Banking on every HTTP `/balances` call, burning the 4/day/ASPSP rate limit)
 - "Noch keine Daten" state now has explicit styling + hint to click Aktualisieren
 
+## [0.11.1] — 2026-04-20
+
+### Fixed
+- Btn-demo now renders neutral/ghost by default — orange fill only when demo mode is active (btn-demo-active), preventing false "already in demo" appearance
+- Refresh race eliminated — after POST /refresh, poll for entity state change (≤5s, 500ms ticks) before calling _rebuild(), avoiding stale hass.states read that returned accountCount=0 and flashed onboarding screen
+- _onHassChanged no longer advances _prevStateHash when _loading=true; instead sets _pendingRebuild=true so _rebuild retries immediately after the in-flight rebuild finishes, closing the concurrent-rebuild deadlock
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.11.0"
+VERSION = "0.11.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -21,6 +21,7 @@ class FdDataProvider extends HTMLElement {
     this._prevStateHash = "";
     this._initialRebuildDone = false;
     this._loading = false;
+    this._pendingRebuild = false;
     this._demoMode = false;
     this._demoToggling = false;
     // Entity registry map: entity_id → unique_id (for our platform only)
@@ -212,6 +213,10 @@ class FdDataProvider extends HTMLElement {
     }));
 
     let resultStatus = null;
+    // Capture the current state hash so we can detect when coordinator
+    // has pushed fresh entity state after the refresh completes.
+    const preRefreshHash = this._computeStateHash();
+
     try {
       // Dedicated endpoint blocks until the refresh completes and
       // returns structured stats. Using this instead of the HA service
@@ -235,8 +240,35 @@ class FdDataProvider extends HTMLElement {
       console.warn("fd-data-provider: /refresh endpoint failed:", e);
     }
 
-    // Force immediate rebuild — allow API fallback for household/recurring
+    // Do NOT call _rebuild() immediately — the HA coordinator pushes entity
+    // state via WebSocket asynchronously, so hass.states may still be stale.
+    // Instead, reset the hash so the next set hass() tick triggers a rebuild
+    // with the fresh states. Also set _pendingRebuild so that if a rebuild
+    // is currently in flight it will re-run once it finishes.
     this._prevStateHash = "";
+    this._pendingRebuild = false; // clear any stale pending flag
+
+    // Poll for fresh states for up to 5 s (max ~10 ticks, 500 ms apart).
+    // As soon as the state hash changes (coordinator pushed new values) OR
+    // we time out, trigger one authoritative rebuild with API fallback.
+    // This terminates unconditionally — no infinite loops.
+    const POLL_INTERVAL = 500;
+    const POLL_MAX = 10;
+    let pollCount = 0;
+    await new Promise((resolve) => {
+      const poll = () => {
+        pollCount++;
+        const currentHash = this._computeStateHash();
+        if (currentHash !== preRefreshHash || pollCount >= POLL_MAX) {
+          resolve();
+        } else {
+          setTimeout(poll, POLL_INTERVAL);
+        }
+      };
+      // First tick after a short delay so the WS push can arrive
+      setTimeout(poll, POLL_INTERVAL);
+    });
+
     await this._rebuild(true);
 
     if (resultStatus && resultStatus.stats) {
@@ -271,6 +303,15 @@ class FdDataProvider extends HTMLElement {
     // First call must always trigger rebuild (even with empty hash)
     if (this._initialRebuildDone && hash === this._prevStateHash) return;
     this._initialRebuildDone = true;
+    // Only advance the hash AFTER rebuild completes — if _rebuild() bails
+    // early due to _loading=true (race with a concurrent rebuild), do NOT
+    // update _prevStateHash so the next hass tick will retry.
+    if (this._loading) {
+      // A rebuild is already in flight; schedule a retry after it finishes.
+      // _pendingRebuild is cleared inside _rebuild() in the finally block.
+      this._pendingRebuild = true;
+      return;
+    }
     this._prevStateHash = hash;
     this._rebuild();
   }
@@ -444,6 +485,15 @@ class FdDataProvider extends HTMLElement {
       }
     } finally {
       this._loading = false;
+      // If a hass-change arrived while we were loading, run a fresh rebuild
+      // now that the lock is released. This prevents the race where
+      // _onHassChanged saw _loading=true and skipped updating _prevStateHash,
+      // leaving the panel stuck on stale (empty) data after a refresh.
+      if (this._pendingRebuild) {
+        this._pendingRebuild = false;
+        // Re-enter _onHassChanged so hash comparison runs cleanly
+        this._onHassChanged();
+      }
     }
   }
 }

--- a/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/custom_components/finance_dashboard/frontend/fd-header.js
@@ -189,21 +189,25 @@ h1 {
   font-weight: 600;
 }
 .btn-demo {
-  border-color: var(--demo);
-  background: rgba(243, 156, 18, 0.15);
-  color: var(--demo);
-  font-weight: 600;
+  /* Neutral ghost style — matches secondary buttons, no orange hint */
+  border-color: var(--bd);
+  background: var(--sf);
+  color: var(--tx2);
 }
 .btn-demo:hover {
-  background: rgba(243, 156, 18, 0.25);
+  background: var(--sf2);
+  color: var(--tx);
 }
 .btn-demo-active {
+  /* Filled orange only when demo mode is ON */
+  border-color: var(--demo);
   background: var(--demo);
   color: #0a0a0f;
   font-weight: 600;
 }
 .btn-demo-active:hover {
   background: #e67e22;
+  border-color: #e67e22;
 }
 .ts-stack {
   display: flex;

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -195,6 +195,15 @@ class FinanceDashboardPanel extends HTMLElement {
       return;
     }
 
+    // While a refresh is in flight and there's no data yet, keep the
+    // user on the "Lade Finanzdaten…" screen instead of flashing
+    // the onboarding prompt momentarily.
+    if (data.isRefreshing && data.accountCount === 0 && !data.demoMode) {
+      content.className = "loading";
+      content.innerHTML = "Daten werden geladen\u2026";
+      return;
+    }
+
     // Onboarding: no accounts and no demo → show welcome with inline wizard CTA
     if (data.accountCount === 0 && !data.demoMode) {
       content.className = "";

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.11.0"
+  "version": "0.11.1"
 }

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 
 
+
+## 0.11.1
+- Btn-demo now renders neutral/ghost by default — orange fill only when demo mode is active (btn-demo-active), preventing false "already in demo" appearance
+- Refresh race eliminated — after POST /refresh, poll for entity state change (≤5s, 500ms ticks) before calling _rebuild(), avoiding stale hass.states read that returned accountCount=0 and flashed onboarding screen
+- _onHassChanged no longer advances _prevStateHash when _loading=true; instead sets _pendingRebuild=true so _rebuild retries immediately after the in-flight rebuild finishes, closing the concurrent-rebuild deadlock
+
 ## 0.11.0
 - Separate cache-reads from live API fetches — `manager.async_get_balance()` now returns cached balances only (was hitting Enable Banking on every HTTP `/balances` call, burning the 4/day/ASPSP rate limit)
 - Serialise user-triggered refreshes with `asyncio.Lock` to prevent double-click concurrent fetches

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.11.0"
+version: "0.11.1"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.11.0"
+VERSION = "0.11.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -21,6 +21,7 @@ class FdDataProvider extends HTMLElement {
     this._prevStateHash = "";
     this._initialRebuildDone = false;
     this._loading = false;
+    this._pendingRebuild = false;
     this._demoMode = false;
     this._demoToggling = false;
     // Entity registry map: entity_id → unique_id (for our platform only)
@@ -212,6 +213,10 @@ class FdDataProvider extends HTMLElement {
     }));
 
     let resultStatus = null;
+    // Capture the current state hash so we can detect when coordinator
+    // has pushed fresh entity state after the refresh completes.
+    const preRefreshHash = this._computeStateHash();
+
     try {
       // Dedicated endpoint blocks until the refresh completes and
       // returns structured stats. Using this instead of the HA service
@@ -235,8 +240,35 @@ class FdDataProvider extends HTMLElement {
       console.warn("fd-data-provider: /refresh endpoint failed:", e);
     }
 
-    // Force immediate rebuild — allow API fallback for household/recurring
+    // Do NOT call _rebuild() immediately — the HA coordinator pushes entity
+    // state via WebSocket asynchronously, so hass.states may still be stale.
+    // Instead, reset the hash so the next set hass() tick triggers a rebuild
+    // with the fresh states. Also set _pendingRebuild so that if a rebuild
+    // is currently in flight it will re-run once it finishes.
     this._prevStateHash = "";
+    this._pendingRebuild = false; // clear any stale pending flag
+
+    // Poll for fresh states for up to 5 s (max ~10 ticks, 500 ms apart).
+    // As soon as the state hash changes (coordinator pushed new values) OR
+    // we time out, trigger one authoritative rebuild with API fallback.
+    // This terminates unconditionally — no infinite loops.
+    const POLL_INTERVAL = 500;
+    const POLL_MAX = 10;
+    let pollCount = 0;
+    await new Promise((resolve) => {
+      const poll = () => {
+        pollCount++;
+        const currentHash = this._computeStateHash();
+        if (currentHash !== preRefreshHash || pollCount >= POLL_MAX) {
+          resolve();
+        } else {
+          setTimeout(poll, POLL_INTERVAL);
+        }
+      };
+      // First tick after a short delay so the WS push can arrive
+      setTimeout(poll, POLL_INTERVAL);
+    });
+
     await this._rebuild(true);
 
     if (resultStatus && resultStatus.stats) {
@@ -271,6 +303,15 @@ class FdDataProvider extends HTMLElement {
     // First call must always trigger rebuild (even with empty hash)
     if (this._initialRebuildDone && hash === this._prevStateHash) return;
     this._initialRebuildDone = true;
+    // Only advance the hash AFTER rebuild completes — if _rebuild() bails
+    // early due to _loading=true (race with a concurrent rebuild), do NOT
+    // update _prevStateHash so the next hass tick will retry.
+    if (this._loading) {
+      // A rebuild is already in flight; schedule a retry after it finishes.
+      // _pendingRebuild is cleared inside _rebuild() in the finally block.
+      this._pendingRebuild = true;
+      return;
+    }
     this._prevStateHash = hash;
     this._rebuild();
   }
@@ -444,6 +485,15 @@ class FdDataProvider extends HTMLElement {
       }
     } finally {
       this._loading = false;
+      // If a hass-change arrived while we were loading, run a fresh rebuild
+      // now that the lock is released. This prevents the race where
+      // _onHassChanged saw _loading=true and skipped updating _prevStateHash,
+      // leaving the panel stuck on stale (empty) data after a refresh.
+      if (this._pendingRebuild) {
+        this._pendingRebuild = false;
+        // Re-enter _onHassChanged so hash comparison runs cleanly
+        this._onHassChanged();
+      }
     }
   }
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-header.js
@@ -189,21 +189,25 @@ h1 {
   font-weight: 600;
 }
 .btn-demo {
-  border-color: var(--demo);
-  background: rgba(243, 156, 18, 0.15);
-  color: var(--demo);
-  font-weight: 600;
+  /* Neutral ghost style — matches secondary buttons, no orange hint */
+  border-color: var(--bd);
+  background: var(--sf);
+  color: var(--tx2);
 }
 .btn-demo:hover {
-  background: rgba(243, 156, 18, 0.25);
+  background: var(--sf2);
+  color: var(--tx);
 }
 .btn-demo-active {
+  /* Filled orange only when demo mode is ON */
+  border-color: var(--demo);
   background: var(--demo);
   color: #0a0a0f;
   font-weight: 600;
 }
 .btn-demo-active:hover {
   background: #e67e22;
+  border-color: #e67e22;
 }
 .ts-stack {
   display: flex;

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -195,6 +195,15 @@ class FinanceDashboardPanel extends HTMLElement {
       return;
     }
 
+    // While a refresh is in flight and there's no data yet, keep the
+    // user on the "Lade Finanzdaten…" screen instead of flashing
+    // the onboarding prompt momentarily.
+    if (data.isRefreshing && data.accountCount === 0 && !data.demoMode) {
+      content.className = "loading";
+      content.innerHTML = "Daten werden geladen\u2026";
+      return;
+    }
+
     // Onboarding: no accounts and no demo → show welcome with inline wizard CTA
     if (data.accountCount === 0 && !data.demoMode) {
       content.className = "";

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.11.0"
+  "version": "0.11.1"
 }


### PR DESCRIPTION
## Summary

Hotfix for three regressions after v0.11.0:

1. **Demo button always looked orange** — `btn-demo` class had orange border+bg+text by default, giving the impression demo mode was active even when off. Fixed: default is now neutral ghost; only `btn-demo-active` is filled orange.

2. **Demo mode appeared broken** — root cause was #1 (button never visually changed on toggle). Data path through `generate_demo_data() → _loadDemoData → fd-data-updated → _onData` is correct.

3. **Refresh button: short flash, then empty panel** — two coupled races:
   - After `POST /refresh` returned, `_rebuild()` fired immediately while the coordinator's state push was still in-flight. Panel read `accountCount=0`, rendered onboarding screen.
   - `_onHassChanged()` advanced `_prevStateHash` before calling `_rebuild()`. When `_rebuild()` bailed (loading guard), the next hass tick skipped the rebuild because the hash was already up-to-date.

   Fix: after `POST /refresh`, poll up to 10×500ms for an entity state-hash change before `_rebuild(true)`. `_onHassChanged()` no longer advances the hash while `_loading=true`; it sets `_pendingRebuild=true` and the `finally` block re-enters.

## Verification
- `python -m py_compile` on touched backend files (src + addon payload): pass
- `node --check` on `fd-header.js`, `fd-data-provider.js`, `finance-dashboard-panel.js` (src + addon payload): pass
- `bump_versions.py` → 0.11.0 → 0.11.1 aligned
- `sync_addon_payload.py --check` → in sync

## Notes
Codex review skipped (usage limit until Apr 23). Fixes were scoped by prior diagnosis and validated via syntax checks.