### PR TITLE
feat(frontend): imported transactions log card (v0.12.0)

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,14 @@
 # Build Log
 
+## 0.12.0 — 2026-04-23
+Version: 0.12.0
+Branch: claude/gallant-mestorf-fcf6f0
+PR: (pending)
+Changes:
+- feat(frontend): new `fd-transactions-log` card shows imported (cached) transactions after at least one bank is linked and a refresh ran — date, counterparty, description, category badge, account, coloured amount, "vorgemerkt" flag for pending items; collapses to 25 rows with "Alle N anzeigen" toggle (cap 100 from the API)
+- feat(frontend): `fd-data-provider` caches `/api/finance_dashboard/transactions` in-memory, refetches on user-triggered refresh and on first rebuild with linked accounts — entity-only state changes no longer trigger redundant fetches, and the endpoint is cache-read only (unbounded-safe, no Enable Banking call)
+- refactor(panel): register `fd-transactions-log.js` in `LOVELACE_COMPONENTS`, append component after `fd-recurring-list` in the shell's component tree
+
 ## 0.11.1 — 2026-04-20
 Version: 0.11.1
 Branch: claude/fix-refresh-demo-race-0-11-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,13 +376,3 @@ All notable changes to the Finance will be documented in this file.
 
 ### Changed
 - Register `fd-transactions-log.js` in `LOVELACE_COMPONENTS`, append component after `fd-recurring-list` in the shell's component tree
-
-### Fixed
-- Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
-- Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild
-- Restart notification no longer lost due to race condition in entry setup — preserves issue when marker file exists and polls immediately
-- Add DataUpdateCoordinator — entities no longer call banking API directly
-- Sensor update interval 10 min via coordinator (was ~30 s per entity → rate-limit exhaustion)
-- Panel refresh on connectedCallback + 10-min auto-timer instead of every hass setter
-- Lovelace card throttles API calls to max once per 10 min (was every hass setter)
-- Manual refresh_transactions service triggers coordinator push to entities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,15 @@ All notable changes to the Finance will be documented in this file.
 - Refresh race eliminated — after POST /refresh, poll for entity state change (≤5s, 500ms ticks) before calling _rebuild(), avoiding stale hass.states read that returned accountCount=0 and flashed onboarding screen
 - _onHassChanged no longer advances _prevStateHash when _loading=true; instead sets _pendingRebuild=true so _rebuild retries immediately after the in-flight rebuild finishes, closing the concurrent-rebuild deadlock
 
+## [0.12.0] — 2026-04-23
+
+### Added
+- New `fd-transactions-log` card shows imported (cached) transactions after at least one bank is linked and a refresh ran — date, counterparty, description, category badge, account, coloured amount, "vorgemerkt" flag for pending items; collapses to 25 rows with "Alle N anzeigen" toggle (cap 100 from the API)
+- `fd-data-provider` caches `/api/finance_dashboard/transactions` in-memory, refetches on user-triggered refresh and on first rebuild with linked accounts — entity-only state changes no longer trigger redundant fetches, and the endpoint is cache-read only (unbounded-safe, no Enable Banking call)
+
+### Changed
+- Register `fd-transactions-log.js` in `LOVELACE_COMPONENTS`, append component after `fd-recurring-list` in the shell's component tree
+
 ### Fixed
 - Prevent infinite loading spinner when no fd_ entities exist — data provider now always triggers initial rebuild
 - Dashboard no longer stuck on "Lade Finanzdaten..." when no finance entities exist — data provider always triggers initial rebuild

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.11.1"
+VERSION = "0.12.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -29,6 +29,11 @@ class FdDataProvider extends HTMLElement {
     this._registryLoading = false;
     // Unsubscribe handle for entity_registry_updated subscription
     this._registryUnsub = null;
+    // Cached admin-only transaction list (from /transactions, cache-read).
+    // Kept across rebuilds so entity-only state changes don't trigger new
+    // fetches. Refreshed on first rebuild with accounts and on every
+    // user-triggered refresh().
+    this._cachedTransactions = [];
   }
 
   disconnectedCallback() {
@@ -285,6 +290,23 @@ class FdDataProvider extends HTMLElement {
     return resultStatus || {};
   }
 
+  /** Fetch cached transactions (admin-only, cache-read, unbounded-safe). */
+  async _fetchTransactions() {
+    if (!this._hass) return;
+    try {
+      const resp = await this._hass.callApi("GET", `${DOMAIN}/transactions`);
+      if (resp && resp.privacy === "admin_full"
+          && Array.isArray(resp.transactions)) {
+        this._cachedTransactions = resp.transactions;
+      } else {
+        // Non-admin or empty response → no detail view available
+        this._cachedTransactions = [];
+      }
+    } catch (e) {
+      console.warn("fd-data-provider: /transactions fetch failed:", e);
+    }
+  }
+
   /** Fetch the current refresh status (cache-only, unbounded-safe). */
   async fetchRefreshStatus() {
     if (!this._hass) return null;
@@ -470,6 +492,18 @@ class FdDataProvider extends HTMLElement {
           console.warn("fd-data-provider: API fallback for household/recurring failed:", e);
         }
       }
+
+      // 5. Transaction log (cache-read endpoint, unbounded-safe). Fetch on
+      // first rebuild with linked accounts and on every user-triggered
+      // refresh. Skip entirely in demo mode — demo data has no real txns.
+      if (!this._demoMode && data.accountCount > 0) {
+        if (allowApiFallback || this._cachedTransactions.length === 0) {
+          await this._fetchTransactions();
+        }
+      } else if (this._demoMode) {
+        this._cachedTransactions = [];
+      }
+      data.transactions = this._cachedTransactions;
 
       this._data = data;
       data.demoMode = this._demoMode;

--- a/custom_components/finance_dashboard/frontend/fd-transactions-log.js
+++ b/custom_components/finance_dashboard/frontend/fd-transactions-log.js
@@ -1,0 +1,262 @@
+/**
+ * fd-transactions-log — Log of imported (cached) transactions.
+ *
+ * Properties:
+ *   data {object} — Unified data object from fd-data-provider
+ *
+ * Reads data.transactions (admin-only, cache-only). Shows up to 25 rows
+ * by default with an expand toggle to reveal the full cached window
+ * (up to 100 items returned by /api/finance_dashboard/transactions).
+ */
+
+const TX_CAT_LABELS = {
+  housing: "Wohnen", loans: "Kredite", food: "Lebensmittel", utilities: "Nebenkosten",
+  insurance: "Versicherung", subscriptions: "Abos", transport: "Mobilit\u00e4t",
+  cleaning: "Reinigung", income: "Einkommen", transfers: "\u00dcbertr\u00e4ge", other: "Sonstiges",
+};
+
+const DEFAULT_LIMIT = 25;
+
+class FdTransactionsLog extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._data = null;
+    this._expanded = false;
+  }
+
+  set data(v) { this._data = v; this._render(); }
+
+  _render() {
+    const d = this._data;
+    const txs = Array.isArray(d?.transactions) ? d.transactions : null;
+
+    // Gate: only render if at least one account is linked AND data was
+    // refreshed at least once (lastRefresh is set). Matches the user's
+    // request to reveal the log only after a first successful refresh.
+    const hasAccounts = (d?.accountCount || 0) > 0 || d?.demoMode;
+    const everRefreshed = !!d?.lastRefresh || d?.demoMode;
+    if (!hasAccounts || !everRefreshed) {
+      this.shadowRoot.innerHTML = "";
+      return;
+    }
+
+    if (!txs) {
+      // Data provider is still loading — keep the section hidden rather
+      // than flashing an empty state.
+      this.shadowRoot.innerHTML = "";
+      return;
+    }
+
+    const total = txs.length;
+    const limit = this._expanded ? total : DEFAULT_LIMIT;
+    const visible = txs.slice(0, limit);
+
+    const eur = (v) => new Intl.NumberFormat("de-DE", {
+      style: "currency", currency: "EUR",
+    }).format(Number(v) || 0);
+
+    const rows = visible.map((t) => {
+      const amount = parseFloat(t.amount);
+      const isPositive = !isNaN(amount) && amount > 0;
+      const amountClass = isPositive ? "pos" : "neg";
+      const sign = isPositive ? "+" : "";
+      const label = t.creditor || t.description || "\u2014";
+      const sub = t.creditor && t.description && t.creditor !== t.description
+        ? t.description : "";
+      const cat = TX_CAT_LABELS[t.category] || t.category || "Sonstiges";
+      const dateStr = this._formatDate(t.date);
+      const pending = t.status === "pending"
+        ? `<span class="tx-pending" title="Vorgemerkt (noch nicht gebucht)">vorgemerkt</span>`
+        : "";
+      const account = t.account_name
+        ? `<span class="tx-acc">${this._esc(t.account_name)}</span>`
+        : "";
+
+      return `<div class="tx-item">
+        <div class="tx-date">${this._esc(dateStr)}</div>
+        <div class="tx-main">
+          <div class="tx-label">${this._esc(label)} ${pending}</div>
+          ${sub ? `<div class="tx-sub">${this._esc(sub)}</div>` : ""}
+          <div class="tx-meta">
+            <span class="tx-cat">${this._esc(cat)}</span>
+            ${account}
+          </div>
+        </div>
+        <div class="tx-amount ${amountClass}">${sign}${eur(amount)}</div>
+      </div>`;
+    }).join("");
+
+    const toggleBtn = total > DEFAULT_LIMIT
+      ? `<button class="tx-toggle" id="toggleBtn">
+          ${this._expanded ? "Weniger anzeigen" : `Alle ${total} anzeigen`}
+        </button>`
+      : "";
+
+    const emptyState = total === 0
+      ? `<div class="tx-empty">Noch keine Transaktionen im Cache. Nach der n\u00e4chsten Aktualisierung erscheinen sie hier.</div>`
+      : "";
+
+    this.shadowRoot.innerHTML = `
+<style>
+:host {
+  --sf: var(--card-background-color, #12121a);
+  --sf2: #1a1a28;
+  --bd: rgba(255,255,255,0.06);
+  --tx2: var(--secondary-text-color, #9898a8);
+  --dg: #e74c3c;
+  --gn: #4ecca3;
+  --wn: #f39c12;
+  --r: 14px;
+  display: block;
+  margin-bottom: 20px;
+}
+.card {
+  background: var(--sf);
+  border: 1px solid var(--bd);
+  border-radius: var(--r);
+}
+.card-h {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--bd);
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.card-h .count {
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--tx2);
+}
+.tx-list {
+  padding: 6px 18px 12px;
+  max-height: 540px;
+  overflow-y: auto;
+}
+.tx-item {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bd);
+  font-size: 13px;
+}
+.tx-item:last-child { border-bottom: none; }
+.tx-date {
+  font-size: 11px;
+  color: var(--tx2);
+  font-variant-numeric: tabular-nums;
+  padding-top: 2px;
+  white-space: nowrap;
+}
+.tx-main { min-width: 0; }
+.tx-label {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.tx-sub {
+  font-size: 11px;
+  color: var(--tx2);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tx-meta {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.tx-cat {
+  font-size: 10px;
+  color: var(--tx2);
+  background: var(--sf2);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.tx-acc {
+  font-size: 10px;
+  color: var(--tx2);
+}
+.tx-pending {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--wn);
+  border: 1px solid var(--wn);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.tx-amount {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  padding-top: 2px;
+}
+.tx-amount.pos { color: var(--gn); }
+.tx-amount.neg { color: var(--dg); }
+.tx-toggle {
+  display: block;
+  margin: 6px auto 0;
+  padding: 6px 16px;
+  background: transparent;
+  border: 1px solid var(--bd);
+  border-radius: 8px;
+  color: var(--tx2);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.tx-toggle:hover { color: var(--tx2); border-color: var(--tx2); }
+.tx-empty {
+  padding: 24px 18px;
+  color: var(--tx2);
+  font-size: 13px;
+  text-align: center;
+}
+</style>
+<div class="card">
+  <div class="card-h">
+    <span>Importierte Transaktionen</span>
+    <span class="count">${total} im Cache</span>
+  </div>
+  ${total === 0 ? emptyState : `<div class="tx-list">${rows}</div>${toggleBtn}`}
+</div>`;
+
+    const btn = this.shadowRoot.getElementById("toggleBtn");
+    if (btn) {
+      btn.addEventListener("click", () => {
+        this._expanded = !this._expanded;
+        this._render();
+      });
+    }
+  }
+
+  _formatDate(iso) {
+    if (!iso) return "";
+    // Expect "YYYY-MM-DD". Fall back to raw string on mismatch.
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+    if (!m) return iso;
+    return `${m[3]}.${m[2]}.`;
+  }
+
+  _esc(s) {
+    if (s === null || s === undefined) return "";
+    const d = document.createElement("div");
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+}
+
+customElements.define("fd-transactions-log", FdTransactionsLog);

--- a/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -9,6 +9,7 @@
  *   fd-category-section  → donut chart + top-3 + fix/var
  *   fd-cost-distribution → category cost bar (when no household)
  *   fd-recurring-list    → recurring payments
+ *   fd-transactions-log  → imported transactions (admin, cache-only)
  *
  * Data flow: fd-data-provider reads HA entities + one API call,
  * dispatches "fd-data-updated" → shell pushes data to all children.
@@ -267,6 +268,12 @@ class FinanceDashboardPanel extends HTMLElement {
     const recurring = document.createElement("fd-recurring-list");
     recurring.data = data;
     content.appendChild(recurring);
+
+    // Transaction log (cached, admin-only). Gated inside the component:
+    // only renders after at least one bank is linked AND one refresh ran.
+    const txLog = document.createElement("fd-transactions-log");
+    txLog.data = data;
+    content.appendChild(txLog);
   }
 }
 

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.11.1"
+  "version": "0.12.0"
 }

--- a/custom_components/finance_dashboard/panel.py
+++ b/custom_components/finance_dashboard/panel.py
@@ -32,6 +32,7 @@ LOVELACE_COMPONENTS = [
     f"{STATIC_BASE}/fd-category-section.js",
     f"{STATIC_BASE}/fd-cost-distribution.js",
     f"{STATIC_BASE}/fd-recurring-list.js",
+    f"{STATIC_BASE}/fd-transactions-log.js",
     f"{STATIC_BASE}/fd-budget-config.js",
     f"{STATIC_BASE}/fd-categorize.js",
     f"{STATIC_BASE}/fd-setup-wizard.js",

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 
 
+
+## 0.12.0
+- New `fd-transactions-log` card shows imported (cached) transactions after at least one bank is linked and a refresh ran — date, counterparty, description, category badge, account, coloured amount, "vorgemerkt" flag for pending items; collapses to 25 rows with "Alle N anzeigen" toggle (cap 100 from the API)
+- `fd-data-provider` caches `/api/finance_dashboard/transactions` in-memory, refetches on user-triggered refresh and on first rebuild with linked accounts — entity-only state changes no longer trigger redundant fetches, and the endpoint is cache-read only (unbounded-safe, no Enable Banking call)
+- Register `fd-transactions-log.js` in `LOVELACE_COMPONENTS`, append component after `fd-recurring-list` in the shell's component tree
+
 ## 0.11.1
 - Btn-demo now renders neutral/ghost by default — orange fill only when demo mode is active (btn-demo-active), preventing false "already in demo" appearance
 - Refresh race eliminated — after POST /refresh, poll for entity state change (≤5s, 500ms ticks) before calling _rebuild(), avoiding stale hass.states read that returned accountCount=0 and flashed onboarding screen

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,5 +1,5 @@
 name: Finance Dashboard
-version: "0.11.1"
+version: "0.12.0"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.11.1"
+VERSION = "0.12.0"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-data-provider.js
@@ -29,6 +29,11 @@ class FdDataProvider extends HTMLElement {
     this._registryLoading = false;
     // Unsubscribe handle for entity_registry_updated subscription
     this._registryUnsub = null;
+    // Cached admin-only transaction list (from /transactions, cache-read).
+    // Kept across rebuilds so entity-only state changes don't trigger new
+    // fetches. Refreshed on first rebuild with accounts and on every
+    // user-triggered refresh().
+    this._cachedTransactions = [];
   }
 
   disconnectedCallback() {
@@ -285,6 +290,23 @@ class FdDataProvider extends HTMLElement {
     return resultStatus || {};
   }
 
+  /** Fetch cached transactions (admin-only, cache-read, unbounded-safe). */
+  async _fetchTransactions() {
+    if (!this._hass) return;
+    try {
+      const resp = await this._hass.callApi("GET", `${DOMAIN}/transactions`);
+      if (resp && resp.privacy === "admin_full"
+          && Array.isArray(resp.transactions)) {
+        this._cachedTransactions = resp.transactions;
+      } else {
+        // Non-admin or empty response → no detail view available
+        this._cachedTransactions = [];
+      }
+    } catch (e) {
+      console.warn("fd-data-provider: /transactions fetch failed:", e);
+    }
+  }
+
   /** Fetch the current refresh status (cache-only, unbounded-safe). */
   async fetchRefreshStatus() {
     if (!this._hass) return null;
@@ -470,6 +492,18 @@ class FdDataProvider extends HTMLElement {
           console.warn("fd-data-provider: API fallback for household/recurring failed:", e);
         }
       }
+
+      // 5. Transaction log (cache-read endpoint, unbounded-safe). Fetch on
+      // first rebuild with linked accounts and on every user-triggered
+      // refresh. Skip entirely in demo mode — demo data has no real txns.
+      if (!this._demoMode && data.accountCount > 0) {
+        if (allowApiFallback || this._cachedTransactions.length === 0) {
+          await this._fetchTransactions();
+        }
+      } else if (this._demoMode) {
+        this._cachedTransactions = [];
+      }
+      data.transactions = this._cachedTransactions;
 
       this._data = data;
       data.demoMode = this._demoMode;

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-transactions-log.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/fd-transactions-log.js
@@ -1,0 +1,262 @@
+/**
+ * fd-transactions-log — Log of imported (cached) transactions.
+ *
+ * Properties:
+ *   data {object} — Unified data object from fd-data-provider
+ *
+ * Reads data.transactions (admin-only, cache-only). Shows up to 25 rows
+ * by default with an expand toggle to reveal the full cached window
+ * (up to 100 items returned by /api/finance_dashboard/transactions).
+ */
+
+const TX_CAT_LABELS = {
+  housing: "Wohnen", loans: "Kredite", food: "Lebensmittel", utilities: "Nebenkosten",
+  insurance: "Versicherung", subscriptions: "Abos", transport: "Mobilit\u00e4t",
+  cleaning: "Reinigung", income: "Einkommen", transfers: "\u00dcbertr\u00e4ge", other: "Sonstiges",
+};
+
+const DEFAULT_LIMIT = 25;
+
+class FdTransactionsLog extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._data = null;
+    this._expanded = false;
+  }
+
+  set data(v) { this._data = v; this._render(); }
+
+  _render() {
+    const d = this._data;
+    const txs = Array.isArray(d?.transactions) ? d.transactions : null;
+
+    // Gate: only render if at least one account is linked AND data was
+    // refreshed at least once (lastRefresh is set). Matches the user's
+    // request to reveal the log only after a first successful refresh.
+    const hasAccounts = (d?.accountCount || 0) > 0 || d?.demoMode;
+    const everRefreshed = !!d?.lastRefresh || d?.demoMode;
+    if (!hasAccounts || !everRefreshed) {
+      this.shadowRoot.innerHTML = "";
+      return;
+    }
+
+    if (!txs) {
+      // Data provider is still loading — keep the section hidden rather
+      // than flashing an empty state.
+      this.shadowRoot.innerHTML = "";
+      return;
+    }
+
+    const total = txs.length;
+    const limit = this._expanded ? total : DEFAULT_LIMIT;
+    const visible = txs.slice(0, limit);
+
+    const eur = (v) => new Intl.NumberFormat("de-DE", {
+      style: "currency", currency: "EUR",
+    }).format(Number(v) || 0);
+
+    const rows = visible.map((t) => {
+      const amount = parseFloat(t.amount);
+      const isPositive = !isNaN(amount) && amount > 0;
+      const amountClass = isPositive ? "pos" : "neg";
+      const sign = isPositive ? "+" : "";
+      const label = t.creditor || t.description || "\u2014";
+      const sub = t.creditor && t.description && t.creditor !== t.description
+        ? t.description : "";
+      const cat = TX_CAT_LABELS[t.category] || t.category || "Sonstiges";
+      const dateStr = this._formatDate(t.date);
+      const pending = t.status === "pending"
+        ? `<span class="tx-pending" title="Vorgemerkt (noch nicht gebucht)">vorgemerkt</span>`
+        : "";
+      const account = t.account_name
+        ? `<span class="tx-acc">${this._esc(t.account_name)}</span>`
+        : "";
+
+      return `<div class="tx-item">
+        <div class="tx-date">${this._esc(dateStr)}</div>
+        <div class="tx-main">
+          <div class="tx-label">${this._esc(label)} ${pending}</div>
+          ${sub ? `<div class="tx-sub">${this._esc(sub)}</div>` : ""}
+          <div class="tx-meta">
+            <span class="tx-cat">${this._esc(cat)}</span>
+            ${account}
+          </div>
+        </div>
+        <div class="tx-amount ${amountClass}">${sign}${eur(amount)}</div>
+      </div>`;
+    }).join("");
+
+    const toggleBtn = total > DEFAULT_LIMIT
+      ? `<button class="tx-toggle" id="toggleBtn">
+          ${this._expanded ? "Weniger anzeigen" : `Alle ${total} anzeigen`}
+        </button>`
+      : "";
+
+    const emptyState = total === 0
+      ? `<div class="tx-empty">Noch keine Transaktionen im Cache. Nach der n\u00e4chsten Aktualisierung erscheinen sie hier.</div>`
+      : "";
+
+    this.shadowRoot.innerHTML = `
+<style>
+:host {
+  --sf: var(--card-background-color, #12121a);
+  --sf2: #1a1a28;
+  --bd: rgba(255,255,255,0.06);
+  --tx2: var(--secondary-text-color, #9898a8);
+  --dg: #e74c3c;
+  --gn: #4ecca3;
+  --wn: #f39c12;
+  --r: 14px;
+  display: block;
+  margin-bottom: 20px;
+}
+.card {
+  background: var(--sf);
+  border: 1px solid var(--bd);
+  border-radius: var(--r);
+}
+.card-h {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--bd);
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.card-h .count {
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--tx2);
+}
+.tx-list {
+  padding: 6px 18px 12px;
+  max-height: 540px;
+  overflow-y: auto;
+}
+.tx-item {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bd);
+  font-size: 13px;
+}
+.tx-item:last-child { border-bottom: none; }
+.tx-date {
+  font-size: 11px;
+  color: var(--tx2);
+  font-variant-numeric: tabular-nums;
+  padding-top: 2px;
+  white-space: nowrap;
+}
+.tx-main { min-width: 0; }
+.tx-label {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.tx-sub {
+  font-size: 11px;
+  color: var(--tx2);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tx-meta {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.tx-cat {
+  font-size: 10px;
+  color: var(--tx2);
+  background: var(--sf2);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.tx-acc {
+  font-size: 10px;
+  color: var(--tx2);
+}
+.tx-pending {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--wn);
+  border: 1px solid var(--wn);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.tx-amount {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  padding-top: 2px;
+}
+.tx-amount.pos { color: var(--gn); }
+.tx-amount.neg { color: var(--dg); }
+.tx-toggle {
+  display: block;
+  margin: 6px auto 0;
+  padding: 6px 16px;
+  background: transparent;
+  border: 1px solid var(--bd);
+  border-radius: 8px;
+  color: var(--tx2);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.tx-toggle:hover { color: var(--tx2); border-color: var(--tx2); }
+.tx-empty {
+  padding: 24px 18px;
+  color: var(--tx2);
+  font-size: 13px;
+  text-align: center;
+}
+</style>
+<div class="card">
+  <div class="card-h">
+    <span>Importierte Transaktionen</span>
+    <span class="count">${total} im Cache</span>
+  </div>
+  ${total === 0 ? emptyState : `<div class="tx-list">${rows}</div>${toggleBtn}`}
+</div>`;
+
+    const btn = this.shadowRoot.getElementById("toggleBtn");
+    if (btn) {
+      btn.addEventListener("click", () => {
+        this._expanded = !this._expanded;
+        this._render();
+      });
+    }
+  }
+
+  _formatDate(iso) {
+    if (!iso) return "";
+    // Expect "YYYY-MM-DD". Fall back to raw string on mismatch.
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+    if (!m) return iso;
+    return `${m[3]}.${m[2]}.`;
+  }
+
+  _esc(s) {
+    if (s === null || s === undefined) return "";
+    const d = document.createElement("div");
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+}
+
+customElements.define("fd-transactions-log", FdTransactionsLog);

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/frontend/finance-dashboard-panel.js
@@ -9,6 +9,7 @@
  *   fd-category-section  → donut chart + top-3 + fix/var
  *   fd-cost-distribution → category cost bar (when no household)
  *   fd-recurring-list    → recurring payments
+ *   fd-transactions-log  → imported transactions (admin, cache-only)
  *
  * Data flow: fd-data-provider reads HA entities + one API call,
  * dispatches "fd-data-updated" → shell pushes data to all children.
@@ -267,6 +268,12 @@ class FinanceDashboardPanel extends HTMLElement {
     const recurring = document.createElement("fd-recurring-list");
     recurring.data = data;
     content.appendChild(recurring);
+
+    // Transaction log (cached, admin-only). Gated inside the component:
+    // only renders after at least one bank is linked AND one refresh ran.
+    const txLog = document.createElement("fd-transactions-log");
+    txLog.data = data;
+    content.appendChild(txLog);
   }
 }
 

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.11.1"
+  "version": "0.12.0"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/panel.py
@@ -32,6 +32,7 @@ LOVELACE_COMPONENTS = [
     f"{STATIC_BASE}/fd-category-section.js",
     f"{STATIC_BASE}/fd-cost-distribution.js",
     f"{STATIC_BASE}/fd-recurring-list.js",
+    f"{STATIC_BASE}/fd-transactions-log.js",
     f"{STATIC_BASE}/fd-budget-config.js",
     f"{STATIC_BASE}/fd-categorize.js",
     f"{STATIC_BASE}/fd-setup-wizard.js",


### PR DESCRIPTION
## Summary
- New `fd-transactions-log` dashboard card shows cached transactions (admin-only) after at least one bank is linked and one refresh has run.
- `fd-data-provider` caches `/api/finance_dashboard/transactions` in memory, refetches only on user refresh + first rebuild — endpoint stays cache-read (unbounded-safe, no Enable Banking call).
- Registered in `LOVELACE_COMPONENTS`, appended after `fd-recurring-list` in the panel shell.

## Test plan
- [ ] Link a bank, trigger refresh → log appears with date, counterparty, category, account, coloured amount
- [ ] Pending transactions render with "vorgemerkt" badge
- [ ] "Alle N anzeigen" toggle expands from 25 → up to 100 rows
- [ ] No log in demo mode / before first refresh / without linked accounts
- [ ] Non-admin user: `/transactions` returns aggregate-only payload → log silently empty
- [ ] Entity-only state changes do not trigger new `/transactions` fetches (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)