### PR TITLE
fix(core+frontend): reliable refresh + cache (v0.12.1)

### DIFF
--- a/BUILDLOG.md
+++ b/BUILDLOG.md
@@ -1,5 +1,24 @@
 # Build Log
 
+## 0.12.1 — 2026-04-24
+Version: 0.12.1
+Branch: claude/charming-cohen-05563c
+PR: (pending)
+Changes:
+- fix(core): preserve partial balances when Enable Banking rate-limit hits mid-fetch — accounts that succeeded before the 429 no longer lose their fresh value, merged into the existing cache instead of being discarded
+- fix(core): reconstruct `_previous_balances` baseline from cached balances on `async_initialize` so the first refresh after every HA restart no longer fires spurious `fd_balance_changed` events for every account
+- fix(core): balance-refresh end path now merges into existing cache instead of replacing — accounts that errored this round keep their last known value
+- fix(setup): deferred reload after setup-wizard completion now triggers a real live refresh via `manager.async_refresh_transactions()` instead of a cache-only `coordinator.async_refresh()` — entities populate with actual bank data immediately, no more "unavailable" state until the user clicks "Aktualisieren"
+- fix(coordinator): `async_load_cached` failure path publishes an empty snapshot so entities stay `unknown` (recoverable) instead of `unavailable` (stuck) when cache read errors
+- fix(core): `refresh_accounts` service call now pushes the updated state through the coordinator so dashboards reflect the new account metadata immediately, matching `refresh_transactions` behavior
+- fix(core): always load the cached snapshot into the coordinator regardless of `configured`/`demo_mode` state so half-configured entries don't leave entities permanently unavailable
+- fix(number): `BudgetLimitNumber` now inherits from `RestoreEntity` — user-set budget limits survive HA restarts instead of silently resetting to 0
+- fix(select): `SplitModelSelect` and `RemainderModeSelect` listen for config-entry updates and re-sync their current option when the options flow changes the stored key — no more stale display after external option changes
+- fix(api): `/demo/toggle` returns HTTP 503 when no manager is configured instead of toggling a dead `hass.data` flag that nothing reads
+- refactor(enablebanking_client): drop unused `ENABLEBANKING_RATE_LIMIT_DAILY` import, move `RateLimitExceeded` below all imports for a clean module layout
+- docs(__init__): replace stale "GoCardless/Nordigen" docstring with Enable Banking PSD2 reference, document the 4/day/ASPSP rate-limit gate
+- docs(addon): replace stale "GoCardless Open Banking API" description in `finance_dashboard_companion/config.yaml` with Enable Banking PSD2
+
 ## 0.12.0 — 2026-04-23
 Version: 0.12.0
 Branch: claude/gallant-mestorf-fcf6f0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Finance will be documented in this file.
 
+## [0.12.1] — 2026-04-24
+
+### Changed
+- Drop unused `ENABLEBANKING_RATE_LIMIT_DAILY` import, move `RateLimitExceeded` below all imports for a clean module layout
+- Replace stale "GoCardless/Nordigen" docstring in `__init__.py` with Enable Banking PSD2 reference and document the 4/day/ASPSP rate-limit gate
+- Replace stale "GoCardless Open Banking API" description in `finance_dashboard_companion/config.yaml` with Enable Banking PSD2
+
+### Fixed
+- Preserve partial balances when Enable Banking rate-limit hits mid-fetch — accounts that succeeded before the 429 no longer lose their fresh value, merged into the existing cache instead of being discarded
+- Reconstruct `_previous_balances` baseline from cached balances on `async_initialize` so the first refresh after every HA restart no longer fires spurious `fd_balance_changed` events for every account
+- Balance-refresh end path now merges into existing cache instead of replacing — accounts that errored this round keep their last known value
+- Deferred reload after setup-wizard completion now triggers a real live refresh via `manager.async_refresh_transactions()` instead of a cache-only `coordinator.async_refresh()` — entities populate with actual bank data immediately, no more "unavailable" state until the user clicks "Aktualisieren"
+- `async_load_cached` failure path publishes an empty snapshot so entities stay `unknown` (recoverable) instead of `unavailable` (stuck) when cache read errors
+- `refresh_accounts` service call now pushes the updated state through the coordinator so dashboards reflect the new account metadata immediately, matching `refresh_transactions` behavior
+- Always load the cached snapshot into the coordinator regardless of `configured`/`demo_mode` state so half-configured entries don't leave entities permanently unavailable
+- `BudgetLimitNumber` now inherits from `RestoreEntity` — user-set budget limits survive HA restarts instead of silently resetting to 0
+- `SplitModelSelect` and `RemainderModeSelect` listen for config-entry updates and re-sync their current option when the options flow changes the stored key — no more stale display after external option changes
+- `/demo/toggle` returns HTTP 503 when no manager is configured instead of toggling a dead `hass.data` flag that nothing reads
+
 ## [0.7.8] — 2026-03-28
 
 ### Fixed

--- a/custom_components/finance_dashboard/__init__.py
+++ b/custom_components/finance_dashboard/__init__.py
@@ -1,10 +1,14 @@
 """Finance Dashboard — Home Assistant Integration.
 
-Provides a secure finance overview with live banking data via GoCardless/Nordigen
-Open Banking API. Tracks accounts, transactions, and household budgets.
+Provides a secure finance overview with live banking data via the Enable
+Banking PSD2 Open Banking API (JWT-signed RS256). Tracks accounts,
+transactions, and household budgets.
 
 SECURITY: No financial data is ever stored in git or logs.
 All credentials and tokens are stored in HA's encrypted .storage/ directory.
+Live banking calls are gated behind explicit user-triggered paths
+(refresh button, service call, setup bootstrap) to respect Enable
+Banking's 4/day/ASPSP rate limit.
 """
 
 from __future__ import annotations
@@ -88,21 +92,24 @@ async def async_setup_entry(
     # Entities are populated immediately from the transaction cache
     # that was loaded in manager.async_initialize(). The user must
     # click "Aktualisieren" to trigger real banking API calls.
-    if entry.data.get("configured") or manager.demo_mode:
-        async def _initial_load() -> None:
-            try:
-                await coordinator.async_load_cached()
-                _LOGGER.info("Initial cached data loaded (no API calls)")
-            except Exception:
-                _LOGGER.exception("Initial cached data load failed")
+    # Run for ALL entry states (configured / pending / demo) so sensors
+    # always have a valid coordinator snapshot — without this,
+    # half-configured setups leave entities permanently "unavailable"
+    # until a full HA restart.
+    async def _initial_load() -> None:
+        try:
+            await coordinator.async_load_cached()
+            _LOGGER.info("Initial cached data loaded (no API calls)")
+        except Exception:
+            _LOGGER.exception("Initial cached data load failed")
 
-        if hass.is_running:
-            hass.async_create_task(_initial_load())
-        else:
-            hass.bus.async_listen_once(
-                "homeassistant_started",
-                lambda _event: hass.async_create_task(_initial_load()),
-            )
+    if hass.is_running:
+        hass.async_create_task(_initial_load())
+    else:
+        hass.bus.async_listen_once(
+            "homeassistant_started",
+            lambda _event: hass.async_create_task(_initial_load()),
+        )
 
     _LOGGER.info("Finance Dashboard v%s loaded", entry.version)
     return True
@@ -142,6 +149,16 @@ async def _async_register_services(
 
     async def handle_refresh_accounts(call) -> dict:
         await manager.async_refresh_accounts()
+        # Keep entity state in lockstep with the account metadata we
+        # just refreshed — otherwise the next dashboard render reads
+        # stale account data from the coordinator and the user sees
+        # no change despite a successful service call.
+        try:
+            await coordinator.async_refresh()
+        except Exception:
+            _LOGGER.exception(
+                "Coordinator refresh after refresh_accounts failed"
+            )
         return manager.get_refresh_status()
 
     async def handle_refresh_transactions(call) -> dict:

--- a/custom_components/finance_dashboard/api.py
+++ b/custom_components/finance_dashboard/api.py
@@ -561,11 +561,13 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
             # response reaches the frontend before unload kills
             # the HTTP endpoints.  The frontend polls /setup/status
             # until configured=true after the reload completes.
-            # After reload, trigger ONE coordinator refresh so the
-            # newly created entities are populated immediately —
-            # without this the user sees "unavailable" until they
-            # click "Aktualisieren". This is a single user-initiated
-            # call (not a periodic auto-refresh).
+            # After reload, trigger ONE live refresh so the newly
+            # created entities are populated with real bank data
+            # immediately — without this the user sees "unavailable"
+            # (cache is empty on first setup) until they click
+            # "Aktualisieren". This is a single user-initiated call
+            # (completing the setup wizard counts), NOT a periodic
+            # auto-refresh, so it stays inside the 4/day policy.
             async def _deferred_reload() -> None:
                 import asyncio as _aio
 
@@ -578,14 +580,23 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
                     _LOGGER.exception("Deferred entry reload failed")
                     return
                 try:
-                    coordinator = hass.data.get(DOMAIN, {}).get(
+                    domain_data = hass.data.get(DOMAIN, {})
+                    new_manager = domain_data.get(entry.entry_id)
+                    coordinator = domain_data.get(
                         f"{entry.entry_id}_coordinator"
                     )
-                    if coordinator:
+                    if new_manager is not None:
+                        # Explicit live fetch — the setup wizard click
+                        # is the user-initiated trigger. Populates both
+                        # transactions and balances in one round.
+                        await new_manager.async_refresh_transactions()
+                    if coordinator is not None:
+                        # Push the fresh cache through the coordinator so
+                        # all entities pick up the new values at once.
                         await coordinator.async_refresh()
-                        _LOGGER.info(
-                            "Initial post-setup refresh completed"
-                        )
+                    _LOGGER.info(
+                        "Initial post-setup refresh completed"
+                    )
                 except Exception:
                     _LOGGER.exception(
                         "Initial post-setup refresh failed"
@@ -1078,33 +1089,36 @@ class FinanceDashboardDemoToggleView(HomeAssistantView):
 
         manager = _get_manager(hass)
 
-        if manager:
-            enabled = not manager.demo_mode
-            manager.set_demo_mode(enabled)
-
-            # Persist to entry.options so demo survives HA restarts
-            entry = hass.data.get(DOMAIN, {}).get("entry")
-            if entry:
-                new_options = {**entry.options, "demo_mode": enabled}
-                hass.config_entries.async_update_entry(
-                    entry, options=new_options
-                )
-
-            # Trigger coordinator refresh so entities update
-            domain_data = hass.data.get(DOMAIN, {})
-            coordinator = (
-                domain_data.get(f"{entry.entry_id}_coordinator")
-                if entry
-                else None
+        if not manager:
+            # Without a manager, demo mode has no meaning — there is no
+            # coordinator to push into, no entities to update, and no
+            # persistence path. Return 503 so the frontend can guide the
+            # user to complete the setup wizard first.
+            return self.json(
+                {"error": "Not configured"}, status_code=503
             )
-            if coordinator:
-                await coordinator.async_refresh()
-            return self.json({"demo_mode": enabled})
 
-        # No manager — toggle in hass.data for API-only demo
-        current = hass.data.get(DOMAIN, {}).get("demo_mode", False)
-        hass.data.setdefault(DOMAIN, {})["demo_mode"] = not current
-        return self.json({"demo_mode": not current})
+        enabled = not manager.demo_mode
+        manager.set_demo_mode(enabled)
+
+        # Persist to entry.options so demo survives HA restarts
+        entry = hass.data.get(DOMAIN, {}).get("entry")
+        if entry:
+            new_options = {**entry.options, "demo_mode": enabled}
+            hass.config_entries.async_update_entry(
+                entry, options=new_options
+            )
+
+        # Trigger coordinator refresh so entities update
+        domain_data = hass.data.get(DOMAIN, {})
+        coordinator = (
+            domain_data.get(f"{entry.entry_id}_coordinator")
+            if entry
+            else None
+        )
+        if coordinator:
+            await coordinator.async_refresh()
+        return self.json({"demo_mode": enabled})
 
 
 class FinanceDashboardDemoDataView(HomeAssistantView):

--- a/custom_components/finance_dashboard/const.py
+++ b/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.12.0"
+VERSION = "0.12.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/custom_components/finance_dashboard/coordinator.py
+++ b/custom_components/finance_dashboard/coordinator.py
@@ -55,18 +55,39 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
         Used on startup to feed entities with cached transactions/balances
         without hitting the banking API. The user must click "Aktualisieren"
         to trigger real API calls.
+
+        If the cache load fails, we still publish an empty snapshot so
+        entities render ``unknown`` (cache miss) instead of ``unavailable``
+        (no coordinator data at all). A fresh refresh heals both states.
         """
         try:
             summary = await self._manager.async_get_monthly_summary()
             rate_limited = self._manager.rate_limited_until
             self.async_set_updated_data({
-                "balances": self._manager._balances,
+                "balances": self._manager.get_cached_balances(),
                 "summary": summary,
                 "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
+                "refresh_status": self._manager.get_refresh_status(),
             })
             _LOGGER.debug("Loaded cached data into coordinator (no API calls)")
         except Exception:
             _LOGGER.exception("Failed to load cached data into coordinator")
+            # Publish an empty shell so entities have a valid (even if
+            # empty) coordinator.data dict to read from. Without this,
+            # sensors stay permanently unavailable after a cache-load
+            # error, and no user action can revive them short of a
+            # full restart.
+            try:
+                self.async_set_updated_data({
+                    "balances": {},
+                    "summary": {},
+                    "rate_limited_until": None,
+                    "refresh_status": self._manager.get_refresh_status(),
+                })
+            except Exception:
+                _LOGGER.exception(
+                    "Fallback empty-snapshot publish also failed"
+                )
 
     async def _async_update_data(self) -> dict:
         """Called on demand via async_refresh() (manual refresh only).

--- a/custom_components/finance_dashboard/enablebanking_client.py
+++ b/custom_components/finance_dashboard/enablebanking_client.py
@@ -23,18 +23,16 @@ from typing import Any
 import uuid
 
 import aiohttp
-
-from .const import ENABLEBANKING_RATE_LIMIT_DAILY
-
-
-class RateLimitExceeded(Exception):
-    """Raised when the banking API returns HTTP 429 (daily quota exhausted)."""
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
 from .const import ENABLEBANKING_BASE_URL
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class RateLimitExceeded(Exception):
+    """Raised when the banking API returns HTTP 429 (daily quota exhausted)."""
 
 
 class EnableBankingClient:

--- a/custom_components/finance_dashboard/manager.py
+++ b/custom_components/finance_dashboard/manager.py
@@ -184,6 +184,20 @@ class FinanceDashboardManager:
             # Cached balances survive restart so the UI shows something
             # immediately — they're only reset by an explicit live refresh.
             self._balances = cached.get("balances", {}) or {}
+            # Rebuild the balance-change baseline from the cache, otherwise
+            # the first refresh after every HA restart fires a
+            # fd_balance_changed event for every account (stale baseline =
+            # 0.00 vs. cached value) and spams user automations.
+            for acc_id, data in self._balances.items():
+                raw = data.get("balances") if isinstance(data, dict) else None
+                if not raw:
+                    continue
+                try:
+                    self._previous_balances[acc_id] = float(
+                        raw[0].get("balanceAmount", {}).get("amount", 0)
+                    )
+                except (TypeError, ValueError, IndexError, AttributeError):
+                    continue
             # Rate-limit state must survive restart — otherwise a user
             # who hit HTTP 429 at 23:59 would "reset" by bouncing HA.
             rl = cached.get("rate_limited_until")
@@ -561,7 +575,15 @@ class FinanceDashboardManager:
                     f"Rate-Limit beim Saldo für "
                     f"{account.get('name', account_id)}"
                 )
-                # Serve the cache we have — no further API calls today
+                # Preserve the partial batch we already fetched — without
+                # this, accounts that succeeded BEFORE the 429 would lose
+                # their fresh balance and the UI would show stale numbers
+                # until the next day. Merge into existing cache so other
+                # accounts (not reached this round) keep their last value.
+                if balances:
+                    merged = dict(self._balances)
+                    merged.update(balances)
+                    self._balances = merged
                 return self._balances
             except Exception as exc:
                 _LOGGER.exception(
@@ -596,7 +618,12 @@ class FinanceDashboardManager:
             _LOGGER.exception("Balance change event firing failed — skipping")
 
         if balances:
-            self._balances = balances
+            # Merge so accounts that errored this round keep their
+            # last known cached value instead of silently disappearing
+            # from the dashboard.
+            merged = dict(self._balances)
+            merged.update(balances)
+            self._balances = merged
         return self._balances
 
     async def async_get_balance(self) -> dict[str, Any]:

--- a/custom_components/finance_dashboard/manifest.json
+++ b/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.12.0"
+  "version": "0.12.1"
 }

--- a/custom_components/finance_dashboard/number.py
+++ b/custom_components/finance_dashboard/number.py
@@ -14,6 +14,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DEFAULT_CATEGORIES, DOMAIN
 
@@ -47,8 +48,13 @@ async def async_setup_entry(
     async_add_entities(entities, update_before_add=True)
 
 
-class BudgetLimitNumber(NumberEntity):
-    """Number entity for a category budget limit."""
+class BudgetLimitNumber(NumberEntity, RestoreEntity):
+    """Number entity for a category budget limit.
+
+    Inherits from RestoreEntity so user-set limits survive HA restarts —
+    without this the limits silently reset to 0 on every reload, which
+    is data loss from the user's point of view.
+    """
 
     _attr_mode = NumberMode.BOX
     _attr_native_min_value = 0
@@ -66,12 +72,35 @@ class BudgetLimitNumber(NumberEntity):
         self._attr_unique_id = f"{DOMAIN}_budget_{category}"
         self._attr_name = f"Budget {category.replace('_', ' ').title()}"
         self._attr_icon = CATEGORY_ICONS.get(category, "mdi:cash")
-        # Default value: 0 = no limit set
+        # Default value: 0 = no limit set. Overridden from restored
+        # state in async_added_to_hass() if the entity has been seen
+        # before.
         self._attr_native_value = 0.0
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previously set budget limit, if any."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state in (None, "unknown", "unavailable"):
+            return
+        try:
+            self._attr_native_value = float(last_state.state)
+            _LOGGER.debug(
+                "Restored budget limit for %s: %.2f EUR",
+                self._category,
+                self._attr_native_value,
+            )
+        except (TypeError, ValueError):
+            _LOGGER.debug(
+                "Could not parse restored budget limit for %s: %r",
+                self._category,
+                last_state.state,
+            )
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the budget limit."""
         self._attr_native_value = value
+        self.async_write_ha_state()
         _LOGGER.debug(
             "Budget limit for %s set to %.2f EUR",
             self._category,

--- a/custom_components/finance_dashboard/select.py
+++ b/custom_components/finance_dashboard/select.py
@@ -7,6 +7,7 @@ without going into integration settings.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -44,69 +45,102 @@ async def async_setup_entry(
     )
 
 
-class SplitModelSelect(SelectEntity):
+class _OptionsBackedSelect(SelectEntity):
+    """Base class for selects whose state lives in ``entry.options``.
+
+    Handles:
+    - Initial option from entry.options
+    - Reactive sync when the options flow updates the entry
+    """
+
+    _option_key: str = ""
+    _default_key: str = ""
+    _label_map: dict[str, str] = {}
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize with the current entry option."""
+        self._entry = entry
+        self._attr_options = list(self._label_map.values())
+        current = entry.options.get(self._option_key, self._default_key)
+        self._attr_current_option = self._label_map.get(
+            current, self._label_map[self._default_key]
+        )
+        self._unsub_update: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for options changes so the entity stays in sync."""
+        await super().async_added_to_hass()
+        self._unsub_update = self._entry.add_update_listener(
+            self._async_entry_updated
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the update listener on teardown."""
+        if self._unsub_update is not None:
+            self._unsub_update()
+            self._unsub_update = None
+
+    async def _async_entry_updated(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Refresh current option when the entry options change externally."""
+        current = entry.options.get(self._option_key, self._default_key)
+        label = self._label_map.get(
+            current, self._label_map[self._default_key]
+        )
+        if label != self._attr_current_option:
+            self._attr_current_option = label
+            self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the selected option back into the entry."""
+        # Reverse lookup: display name → storage key
+        key = next(
+            (k for k, v in self._label_map.items() if v == option),
+            self._default_key,
+        )
+        self._attr_current_option = option
+        _LOGGER.info(
+            "%s changed to: %s (%s)",
+            self._option_key,
+            option,
+            key,
+        )
+        new_options = dict(self._entry.options)
+        new_options[self._option_key] = key
+        self.hass.config_entries.async_update_entry(
+            self._entry, options=new_options
+        )
+        self.async_write_ha_state()
+
+
+class SplitModelSelect(_OptionsBackedSelect):
     """Select entity for choosing the budget split model."""
 
     _attr_has_entity_name = True
     _attr_name = "Split Model"
     _attr_icon = "mdi:scale-balance"
+    _option_key = "split_model"
+    _default_key = "proportional"
+    _label_map = SPLIT_MODELS
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize split model select."""
-        self._entry = entry
+        super().__init__(entry)
         self._attr_unique_id = f"{DOMAIN}_split_model"
-        self._attr_options = list(SPLIT_MODELS.values())
-        current = entry.options.get("split_model", "proportional")
-        self._attr_current_option = SPLIT_MODELS.get(
-            current, SPLIT_MODELS["proportional"]
-        )
-
-    async def async_select_option(self, option: str) -> None:
-        """Handle split model change."""
-        # Reverse lookup: display name → key
-        key = next(
-            (k for k, v in SPLIT_MODELS.items() if v == option),
-            "proportional",
-        )
-        self._attr_current_option = option
-        _LOGGER.info("Split model changed to: %s (%s)", option, key)
-
-        # Update the config entry options
-        new_options = dict(self._entry.options)
-        new_options["split_model"] = key
-        self.hass.config_entries.async_update_entry(
-            self._entry, options=new_options
-        )
 
 
-class RemainderModeSelect(SelectEntity):
+class RemainderModeSelect(_OptionsBackedSelect):
     """Select entity for remainder split mode."""
 
     _attr_has_entity_name = True
     _attr_name = "Remainder Mode"
     _attr_icon = "mdi:arrow-split-vertical"
+    _option_key = "remainder_mode"
+    _default_key = "none"
+    _label_map = REMAINDER_MODES
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize remainder mode select."""
-        self._entry = entry
+        super().__init__(entry)
         self._attr_unique_id = f"{DOMAIN}_remainder_mode"
-        self._attr_options = list(REMAINDER_MODES.values())
-        current = entry.options.get("remainder_mode", "none")
-        self._attr_current_option = REMAINDER_MODES.get(
-            current, REMAINDER_MODES["none"]
-        )
-
-    async def async_select_option(self, option: str) -> None:
-        """Handle remainder mode change."""
-        key = next(
-            (k for k, v in REMAINDER_MODES.items() if v == option),
-            "none",
-        )
-        self._attr_current_option = option
-        _LOGGER.info("Remainder mode changed to: %s (%s)", option, key)
-
-        new_options = dict(self._entry.options)
-        new_options["remainder_mode"] = key
-        self.hass.config_entries.async_update_entry(
-            self._entry, options=new_options
-        )

--- a/finance_dashboard_companion/CHANGELOG.md
+++ b/finance_dashboard_companion/CHANGELOG.md
@@ -1,17 +1,19 @@
 # Changelog
 
-
-
-
-
-
-
-
-
-
-
-
-
+## 0.12.1
+- Preserve partial balances when Enable Banking rate-limit hits mid-fetch — accounts that succeeded before the 429 no longer lose their fresh value, merged into the existing cache instead of being discarded
+- Reconstruct `_previous_balances` baseline from cached balances on `async_initialize` so the first refresh after every HA restart no longer fires spurious `fd_balance_changed` events for every account
+- Balance-refresh end path now merges into existing cache instead of replacing — accounts that errored this round keep their last known value
+- Deferred reload after setup-wizard completion now triggers a real live refresh via `manager.async_refresh_transactions()` instead of a cache-only `coordinator.async_refresh()` — entities populate with actual bank data immediately, no more "unavailable" state until the user clicks "Aktualisieren"
+- `async_load_cached` failure path publishes an empty snapshot so entities stay `unknown` (recoverable) instead of `unavailable` (stuck) when cache read errors
+- `refresh_accounts` service call now pushes the updated state through the coordinator so dashboards reflect the new account metadata immediately, matching `refresh_transactions` behavior
+- Always load the cached snapshot into the coordinator regardless of `configured`/`demo_mode` state so half-configured entries don't leave entities permanently unavailable
+- `BudgetLimitNumber` now inherits from `RestoreEntity` — user-set budget limits survive HA restarts instead of silently resetting to 0
+- `SplitModelSelect` and `RemainderModeSelect` listen for config-entry updates and re-sync their current option when the options flow changes the stored key — no more stale display after external option changes
+- `/demo/toggle` returns HTTP 503 when no manager is configured instead of toggling a dead `hass.data` flag that nothing reads
+- Drop unused `ENABLEBANKING_RATE_LIMIT_DAILY` import, move `RateLimitExceeded` below all imports for a clean module layout
+- Docs(__init__): replace stale "GoCardless/Nordigen" docstring with Enable Banking PSD2 reference, document the 4/day/ASPSP rate-limit gate
+- Docs(addon): replace stale "GoCardless Open Banking API" description in `finance_dashboard_companion/config.yaml` with Enable Banking PSD2
 
 ## 0.12.0
 - New `fd-transactions-log` card shows imported (cached) transactions after at least one bank is linked and a refresh ran — date, counterparty, description, category badge, account, coloured amount, "vorgemerkt" flag for pending items; collapses to 25 rows with "Alle N anzeigen" toggle (cap 100 from the API)

--- a/finance_dashboard_companion/config.yaml
+++ b/finance_dashboard_companion/config.yaml
@@ -1,10 +1,11 @@
 name: Finance Dashboard
-version: "0.12.0"
+version: "0.12.1"
 slug: finance_dashboard_companion
 description: >-
   Install or update the Finance Dashboard integration for Home Assistant.
-  Provides secure banking data access via GoCardless Open Banking API
-  with auto-categorization, household budget tracking, and more.
+  Provides secure banking data access via the Enable Banking PSD2 API
+  (JWT RS256, 4/day/ASPSP rate limit) with auto-categorization,
+  household budget tracking, and more.
 url: "https://github.com/Jerry0022/homeassistant-finance"
 startup: once
 boot: auto

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/__init__.py
@@ -1,10 +1,14 @@
 """Finance Dashboard — Home Assistant Integration.
 
-Provides a secure finance overview with live banking data via GoCardless/Nordigen
-Open Banking API. Tracks accounts, transactions, and household budgets.
+Provides a secure finance overview with live banking data via the Enable
+Banking PSD2 Open Banking API (JWT-signed RS256). Tracks accounts,
+transactions, and household budgets.
 
 SECURITY: No financial data is ever stored in git or logs.
 All credentials and tokens are stored in HA's encrypted .storage/ directory.
+Live banking calls are gated behind explicit user-triggered paths
+(refresh button, service call, setup bootstrap) to respect Enable
+Banking's 4/day/ASPSP rate limit.
 """
 
 from __future__ import annotations
@@ -88,21 +92,24 @@ async def async_setup_entry(
     # Entities are populated immediately from the transaction cache
     # that was loaded in manager.async_initialize(). The user must
     # click "Aktualisieren" to trigger real banking API calls.
-    if entry.data.get("configured") or manager.demo_mode:
-        async def _initial_load() -> None:
-            try:
-                await coordinator.async_load_cached()
-                _LOGGER.info("Initial cached data loaded (no API calls)")
-            except Exception:
-                _LOGGER.exception("Initial cached data load failed")
+    # Run for ALL entry states (configured / pending / demo) so sensors
+    # always have a valid coordinator snapshot — without this,
+    # half-configured setups leave entities permanently "unavailable"
+    # until a full HA restart.
+    async def _initial_load() -> None:
+        try:
+            await coordinator.async_load_cached()
+            _LOGGER.info("Initial cached data loaded (no API calls)")
+        except Exception:
+            _LOGGER.exception("Initial cached data load failed")
 
-        if hass.is_running:
-            hass.async_create_task(_initial_load())
-        else:
-            hass.bus.async_listen_once(
-                "homeassistant_started",
-                lambda _event: hass.async_create_task(_initial_load()),
-            )
+    if hass.is_running:
+        hass.async_create_task(_initial_load())
+    else:
+        hass.bus.async_listen_once(
+            "homeassistant_started",
+            lambda _event: hass.async_create_task(_initial_load()),
+        )
 
     _LOGGER.info("Finance Dashboard v%s loaded", entry.version)
     return True
@@ -142,6 +149,16 @@ async def _async_register_services(
 
     async def handle_refresh_accounts(call) -> dict:
         await manager.async_refresh_accounts()
+        # Keep entity state in lockstep with the account metadata we
+        # just refreshed — otherwise the next dashboard render reads
+        # stale account data from the coordinator and the user sees
+        # no change despite a successful service call.
+        try:
+            await coordinator.async_refresh()
+        except Exception:
+            _LOGGER.exception(
+                "Coordinator refresh after refresh_accounts failed"
+            )
         return manager.get_refresh_status()
 
     async def handle_refresh_transactions(call) -> dict:

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/api.py
@@ -561,11 +561,13 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
             # response reaches the frontend before unload kills
             # the HTTP endpoints.  The frontend polls /setup/status
             # until configured=true after the reload completes.
-            # After reload, trigger ONE coordinator refresh so the
-            # newly created entities are populated immediately —
-            # without this the user sees "unavailable" until they
-            # click "Aktualisieren". This is a single user-initiated
-            # call (not a periodic auto-refresh).
+            # After reload, trigger ONE live refresh so the newly
+            # created entities are populated with real bank data
+            # immediately — without this the user sees "unavailable"
+            # (cache is empty on first setup) until they click
+            # "Aktualisieren". This is a single user-initiated call
+            # (completing the setup wizard counts), NOT a periodic
+            # auto-refresh, so it stays inside the 4/day policy.
             async def _deferred_reload() -> None:
                 import asyncio as _aio
 
@@ -578,14 +580,23 @@ class FinanceDashboardSetupCompleteView(HomeAssistantView):
                     _LOGGER.exception("Deferred entry reload failed")
                     return
                 try:
-                    coordinator = hass.data.get(DOMAIN, {}).get(
+                    domain_data = hass.data.get(DOMAIN, {})
+                    new_manager = domain_data.get(entry.entry_id)
+                    coordinator = domain_data.get(
                         f"{entry.entry_id}_coordinator"
                     )
-                    if coordinator:
+                    if new_manager is not None:
+                        # Explicit live fetch — the setup wizard click
+                        # is the user-initiated trigger. Populates both
+                        # transactions and balances in one round.
+                        await new_manager.async_refresh_transactions()
+                    if coordinator is not None:
+                        # Push the fresh cache through the coordinator so
+                        # all entities pick up the new values at once.
                         await coordinator.async_refresh()
-                        _LOGGER.info(
-                            "Initial post-setup refresh completed"
-                        )
+                    _LOGGER.info(
+                        "Initial post-setup refresh completed"
+                    )
                 except Exception:
                     _LOGGER.exception(
                         "Initial post-setup refresh failed"
@@ -1078,33 +1089,36 @@ class FinanceDashboardDemoToggleView(HomeAssistantView):
 
         manager = _get_manager(hass)
 
-        if manager:
-            enabled = not manager.demo_mode
-            manager.set_demo_mode(enabled)
-
-            # Persist to entry.options so demo survives HA restarts
-            entry = hass.data.get(DOMAIN, {}).get("entry")
-            if entry:
-                new_options = {**entry.options, "demo_mode": enabled}
-                hass.config_entries.async_update_entry(
-                    entry, options=new_options
-                )
-
-            # Trigger coordinator refresh so entities update
-            domain_data = hass.data.get(DOMAIN, {})
-            coordinator = (
-                domain_data.get(f"{entry.entry_id}_coordinator")
-                if entry
-                else None
+        if not manager:
+            # Without a manager, demo mode has no meaning — there is no
+            # coordinator to push into, no entities to update, and no
+            # persistence path. Return 503 so the frontend can guide the
+            # user to complete the setup wizard first.
+            return self.json(
+                {"error": "Not configured"}, status_code=503
             )
-            if coordinator:
-                await coordinator.async_refresh()
-            return self.json({"demo_mode": enabled})
 
-        # No manager — toggle in hass.data for API-only demo
-        current = hass.data.get(DOMAIN, {}).get("demo_mode", False)
-        hass.data.setdefault(DOMAIN, {})["demo_mode"] = not current
-        return self.json({"demo_mode": not current})
+        enabled = not manager.demo_mode
+        manager.set_demo_mode(enabled)
+
+        # Persist to entry.options so demo survives HA restarts
+        entry = hass.data.get(DOMAIN, {}).get("entry")
+        if entry:
+            new_options = {**entry.options, "demo_mode": enabled}
+            hass.config_entries.async_update_entry(
+                entry, options=new_options
+            )
+
+        # Trigger coordinator refresh so entities update
+        domain_data = hass.data.get(DOMAIN, {})
+        coordinator = (
+            domain_data.get(f"{entry.entry_id}_coordinator")
+            if entry
+            else None
+        )
+        if coordinator:
+            await coordinator.async_refresh()
+        return self.json({"demo_mode": enabled})
 
 
 class FinanceDashboardDemoDataView(HomeAssistantView):

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/const.py
@@ -4,7 +4,7 @@ DOMAIN = "finance_dashboard"
 PLATFORMS = ["sensor", "number", "select"]
 
 # Version — must match manifest.json and companion config.yaml
-VERSION = "0.12.0"
+VERSION = "0.12.1"
 
 # Panel
 PANEL_URL_PATH = "finance-dashboard"

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/coordinator.py
@@ -55,18 +55,39 @@ class FinanceDashboardCoordinator(DataUpdateCoordinator):
         Used on startup to feed entities with cached transactions/balances
         without hitting the banking API. The user must click "Aktualisieren"
         to trigger real API calls.
+
+        If the cache load fails, we still publish an empty snapshot so
+        entities render ``unknown`` (cache miss) instead of ``unavailable``
+        (no coordinator data at all). A fresh refresh heals both states.
         """
         try:
             summary = await self._manager.async_get_monthly_summary()
             rate_limited = self._manager.rate_limited_until
             self.async_set_updated_data({
-                "balances": self._manager._balances,
+                "balances": self._manager.get_cached_balances(),
                 "summary": summary,
                 "rate_limited_until": rate_limited.isoformat() if rate_limited else None,
+                "refresh_status": self._manager.get_refresh_status(),
             })
             _LOGGER.debug("Loaded cached data into coordinator (no API calls)")
         except Exception:
             _LOGGER.exception("Failed to load cached data into coordinator")
+            # Publish an empty shell so entities have a valid (even if
+            # empty) coordinator.data dict to read from. Without this,
+            # sensors stay permanently unavailable after a cache-load
+            # error, and no user action can revive them short of a
+            # full restart.
+            try:
+                self.async_set_updated_data({
+                    "balances": {},
+                    "summary": {},
+                    "rate_limited_until": None,
+                    "refresh_status": self._manager.get_refresh_status(),
+                })
+            except Exception:
+                _LOGGER.exception(
+                    "Fallback empty-snapshot publish also failed"
+                )
 
     async def _async_update_data(self) -> dict:
         """Called on demand via async_refresh() (manual refresh only).

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/enablebanking_client.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/enablebanking_client.py
@@ -23,18 +23,16 @@ from typing import Any
 import uuid
 
 import aiohttp
-
-from .const import ENABLEBANKING_RATE_LIMIT_DAILY
-
-
-class RateLimitExceeded(Exception):
-    """Raised when the banking API returns HTTP 429 (daily quota exhausted)."""
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
 from .const import ENABLEBANKING_BASE_URL
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class RateLimitExceeded(Exception):
+    """Raised when the banking API returns HTTP 429 (daily quota exhausted)."""
 
 
 class EnableBankingClient:

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manager.py
@@ -184,6 +184,20 @@ class FinanceDashboardManager:
             # Cached balances survive restart so the UI shows something
             # immediately — they're only reset by an explicit live refresh.
             self._balances = cached.get("balances", {}) or {}
+            # Rebuild the balance-change baseline from the cache, otherwise
+            # the first refresh after every HA restart fires a
+            # fd_balance_changed event for every account (stale baseline =
+            # 0.00 vs. cached value) and spams user automations.
+            for acc_id, data in self._balances.items():
+                raw = data.get("balances") if isinstance(data, dict) else None
+                if not raw:
+                    continue
+                try:
+                    self._previous_balances[acc_id] = float(
+                        raw[0].get("balanceAmount", {}).get("amount", 0)
+                    )
+                except (TypeError, ValueError, IndexError, AttributeError):
+                    continue
             # Rate-limit state must survive restart — otherwise a user
             # who hit HTTP 429 at 23:59 would "reset" by bouncing HA.
             rl = cached.get("rate_limited_until")
@@ -561,7 +575,15 @@ class FinanceDashboardManager:
                     f"Rate-Limit beim Saldo für "
                     f"{account.get('name', account_id)}"
                 )
-                # Serve the cache we have — no further API calls today
+                # Preserve the partial batch we already fetched — without
+                # this, accounts that succeeded BEFORE the 429 would lose
+                # their fresh balance and the UI would show stale numbers
+                # until the next day. Merge into existing cache so other
+                # accounts (not reached this round) keep their last value.
+                if balances:
+                    merged = dict(self._balances)
+                    merged.update(balances)
+                    self._balances = merged
                 return self._balances
             except Exception as exc:
                 _LOGGER.exception(
@@ -596,7 +618,12 @@ class FinanceDashboardManager:
             _LOGGER.exception("Balance change event firing failed — skipping")
 
         if balances:
-            self._balances = balances
+            # Merge so accounts that errored this round keep their
+            # last known cached value instead of silently disappearing
+            # from the dashboard.
+            merged = dict(self._balances)
+            merged.update(balances)
+            self._balances = merged
         return self._balances
 
     async def async_get_balance(self) -> dict[str, Any]:

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/manifest.json
@@ -18,5 +18,5 @@
     "cryptography>=42.0.0",
     "ha-customapps>=0.3.0"
   ],
-  "version": "0.12.0"
+  "version": "0.12.1"
 }

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/number.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/number.py
@@ -14,6 +14,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DEFAULT_CATEGORIES, DOMAIN
 
@@ -47,8 +48,13 @@ async def async_setup_entry(
     async_add_entities(entities, update_before_add=True)
 
 
-class BudgetLimitNumber(NumberEntity):
-    """Number entity for a category budget limit."""
+class BudgetLimitNumber(NumberEntity, RestoreEntity):
+    """Number entity for a category budget limit.
+
+    Inherits from RestoreEntity so user-set limits survive HA restarts —
+    without this the limits silently reset to 0 on every reload, which
+    is data loss from the user's point of view.
+    """
 
     _attr_mode = NumberMode.BOX
     _attr_native_min_value = 0
@@ -66,12 +72,35 @@ class BudgetLimitNumber(NumberEntity):
         self._attr_unique_id = f"{DOMAIN}_budget_{category}"
         self._attr_name = f"Budget {category.replace('_', ' ').title()}"
         self._attr_icon = CATEGORY_ICONS.get(category, "mdi:cash")
-        # Default value: 0 = no limit set
+        # Default value: 0 = no limit set. Overridden from restored
+        # state in async_added_to_hass() if the entity has been seen
+        # before.
         self._attr_native_value = 0.0
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previously set budget limit, if any."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state in (None, "unknown", "unavailable"):
+            return
+        try:
+            self._attr_native_value = float(last_state.state)
+            _LOGGER.debug(
+                "Restored budget limit for %s: %.2f EUR",
+                self._category,
+                self._attr_native_value,
+            )
+        except (TypeError, ValueError):
+            _LOGGER.debug(
+                "Could not parse restored budget limit for %s: %r",
+                self._category,
+                last_state.state,
+            )
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the budget limit."""
         self._attr_native_value = value
+        self.async_write_ha_state()
         _LOGGER.debug(
             "Budget limit for %s set to %.2f EUR",
             self._category,

--- a/finance_dashboard_companion/payload/custom_components/finance_dashboard/select.py
+++ b/finance_dashboard_companion/payload/custom_components/finance_dashboard/select.py
@@ -7,6 +7,7 @@ without going into integration settings.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -44,69 +45,102 @@ async def async_setup_entry(
     )
 
 
-class SplitModelSelect(SelectEntity):
+class _OptionsBackedSelect(SelectEntity):
+    """Base class for selects whose state lives in ``entry.options``.
+
+    Handles:
+    - Initial option from entry.options
+    - Reactive sync when the options flow updates the entry
+    """
+
+    _option_key: str = ""
+    _default_key: str = ""
+    _label_map: dict[str, str] = {}
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize with the current entry option."""
+        self._entry = entry
+        self._attr_options = list(self._label_map.values())
+        current = entry.options.get(self._option_key, self._default_key)
+        self._attr_current_option = self._label_map.get(
+            current, self._label_map[self._default_key]
+        )
+        self._unsub_update: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for options changes so the entity stays in sync."""
+        await super().async_added_to_hass()
+        self._unsub_update = self._entry.add_update_listener(
+            self._async_entry_updated
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the update listener on teardown."""
+        if self._unsub_update is not None:
+            self._unsub_update()
+            self._unsub_update = None
+
+    async def _async_entry_updated(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Refresh current option when the entry options change externally."""
+        current = entry.options.get(self._option_key, self._default_key)
+        label = self._label_map.get(
+            current, self._label_map[self._default_key]
+        )
+        if label != self._attr_current_option:
+            self._attr_current_option = label
+            self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the selected option back into the entry."""
+        # Reverse lookup: display name → storage key
+        key = next(
+            (k for k, v in self._label_map.items() if v == option),
+            self._default_key,
+        )
+        self._attr_current_option = option
+        _LOGGER.info(
+            "%s changed to: %s (%s)",
+            self._option_key,
+            option,
+            key,
+        )
+        new_options = dict(self._entry.options)
+        new_options[self._option_key] = key
+        self.hass.config_entries.async_update_entry(
+            self._entry, options=new_options
+        )
+        self.async_write_ha_state()
+
+
+class SplitModelSelect(_OptionsBackedSelect):
     """Select entity for choosing the budget split model."""
 
     _attr_has_entity_name = True
     _attr_name = "Split Model"
     _attr_icon = "mdi:scale-balance"
+    _option_key = "split_model"
+    _default_key = "proportional"
+    _label_map = SPLIT_MODELS
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize split model select."""
-        self._entry = entry
+        super().__init__(entry)
         self._attr_unique_id = f"{DOMAIN}_split_model"
-        self._attr_options = list(SPLIT_MODELS.values())
-        current = entry.options.get("split_model", "proportional")
-        self._attr_current_option = SPLIT_MODELS.get(
-            current, SPLIT_MODELS["proportional"]
-        )
-
-    async def async_select_option(self, option: str) -> None:
-        """Handle split model change."""
-        # Reverse lookup: display name → key
-        key = next(
-            (k for k, v in SPLIT_MODELS.items() if v == option),
-            "proportional",
-        )
-        self._attr_current_option = option
-        _LOGGER.info("Split model changed to: %s (%s)", option, key)
-
-        # Update the config entry options
-        new_options = dict(self._entry.options)
-        new_options["split_model"] = key
-        self.hass.config_entries.async_update_entry(
-            self._entry, options=new_options
-        )
 
 
-class RemainderModeSelect(SelectEntity):
+class RemainderModeSelect(_OptionsBackedSelect):
     """Select entity for remainder split mode."""
 
     _attr_has_entity_name = True
     _attr_name = "Remainder Mode"
     _attr_icon = "mdi:arrow-split-vertical"
+    _option_key = "remainder_mode"
+    _default_key = "none"
+    _label_map = REMAINDER_MODES
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize remainder mode select."""
-        self._entry = entry
+        super().__init__(entry)
         self._attr_unique_id = f"{DOMAIN}_remainder_mode"
-        self._attr_options = list(REMAINDER_MODES.values())
-        current = entry.options.get("remainder_mode", "none")
-        self._attr_current_option = REMAINDER_MODES.get(
-            current, REMAINDER_MODES["none"]
-        )
-
-    async def async_select_option(self, option: str) -> None:
-        """Handle remainder mode change."""
-        key = next(
-            (k for k, v in REMAINDER_MODES.items() if v == option),
-            "none",
-        )
-        self._attr_current_option = option
-        _LOGGER.info("Remainder mode changed to: %s (%s)", option, key)
-
-        new_options = dict(self._entry.options)
-        new_options["remainder_mode"] = key
-        self.hass.config_entries.async_update_entry(
-            self._entry, options=new_options
-        )


### PR DESCRIPTION
## Summary
Release candidate v0.12.1 — fixes the unreliable refresh and stale cache behavior. Full repo audit identified 13 bugs; 11 fixed, 2 deferred as non-blocking perf items.

## RC-Blocker fixes

### Refresh flow
- **B1** — `manager._async_refresh_balances_live` preserves partial balances when rate-limit hits mid-fetch (merge instead of discard).
- **B5** — Deferred reload after setup wizard triggers `manager.async_refresh_transactions()` (real live fetch) instead of cache-only `coordinator.async_refresh()`. Entities populate with actual bank data immediately.
- **B6** — `coordinator.async_load_cached` failure path publishes empty snapshot so entities stay `unknown` (recoverable) instead of `unavailable` (stuck).
- **B7** — `refresh_accounts` service call pushes through coordinator, matching `refresh_transactions` behavior.

### Cache correctness
- **B2** — `_previous_balances` baseline reconstructed from cached balances on `async_initialize`. No more spurious `fd_balance_changed` events for every account after every HA restart.
- **B12** — Always load cached snapshot into coordinator regardless of `configured`/`demo_mode` state.
- Balance merge at end of refresh: accounts that errored this round keep their last known cached value.

### RC-Polish
- **B8** — `BudgetLimitNumber` inherits from `RestoreEntity`. User-set budget limits survive HA restarts.
- **B9** — `SplitModelSelect` and `RemainderModeSelect` listen for config-entry updates via `add_update_listener`.
- **B13** — `/demo/toggle` returns HTTP 503 when no manager is configured.
- **B11** — Cleanup `enablebanking_client.py` imports.
- **B3/B4** — Replace stale GoCardless/Nordigen references with Enable Banking PSD2.

## Deferred (post-RC)
- **B10** — `aiohttp.ClientSession` pooling (pure perf, no correctness impact).

## Version
`0.12.0 → 0.12.1` — patch. manifest.json, config.yaml, const.py aligned. Addon payload synced. CHANGELOG + BUILDLOG + addon CHANGELOG updated.

## Test plan
- [ ] Setup wizard: entities populate immediately with real data
- [ ] Refresh button: toast shows stats
- [ ] Rate-limit: 5x refresh → "Morgen verfügbar" chip
- [ ] HA restart: budget limit preserved
- [ ] Options-flow: split_model change → select updates without reload
- [ ] HA restart: no spurious balance_changed events

## Validation (automated)
- py_compile: PASS (22 modules)
- node --check: PASS (17 components)
- YAML/JSON: PASS
- bump_versions --check: 3/3 aligned at 0.12.1
- sync_addon_payload --check: in sync
- sync_changelog --check: up-to-date

Ship-MCP-Tools sind in dieser Session disconnected (Plugin-Cache-Fix für `heartbeat.js` wurde in dieser Session manuell gelegt — wird beim nächsten Session-Start wirksam). Daher PR manuell via `gh api repos/.../pulls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
